### PR TITLE
color: Fix unicode literals in terminal coloring

### DIFF
--- a/src/sqlfluff/cli/helpers.py
+++ b/src/sqlfluff/cli/helpers.py
@@ -1,5 +1,6 @@
 """ CLI helper utilities """
 
+from __future__ import unicode_literals
 from six import StringIO
 import sys
 import textwrap


### PR DESCRIPTION

Thanks for putting `sqlfluff` together @alanmcruickshank -- I believe it has a ton of potential and eagerly await its future development!

While trying it out on Python 2 ran into [the dreaded `\u` escapes](https://matplotlib.org/2.1.1/devel/portable_code.html#the-dreaded-u-escapes). I understand Python 2 is not a priority (and it really should not be), but the fix was quite simple and so I though you may appreciate it.

Do let me know if there is anything else I can help you with in this regard.

Thanks!

-------------------------

* When running on Python 2, `sqlfluff` would produce strings as follows:

       == [\u001b[30;1mtest/fixtures/linter/indentation_error_simple.sql\u001b[0m] \u001b[31mFAIL\u001b[0m
       \u001b[36mL:   2 | P:   1 | L003 |\u001b[0m Single indentation uses a number of spaces not a multiple of 4

* This commit fixes the situation by importing `unicode_literals` form
  `__future__`

Signed-off-by: mr.Shu <mr@shu.io>