### PR TITLE
fix: Paths on separate lines in linting output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ common: &common
         keys:
           - v2-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
+        name: Make directory for test results
+        command: mkdir .test-reports
+    - run:
         name: install dependencies
         command: pip install --user tox
     - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Changed unicode handling for better escape codes in python 2.
+  Thanks [@mrshu](https://github.com/mrshu)
 
 ## [0.0.7] - 2018-11-19
 ### Added

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Alan Cruickshank
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![image](https://img.shields.io/pypi/l/sqlfluff.svg)](https://pypi.org/project/sqlfluff/)
 [![image](https://img.shields.io/pypi/pyversions/sqlfluff.svg)](https://pypi.org/project/sqlfluff/)
 [![codecov](https://codecov.io/gh/alanmcruickshank/sqlfluff/branch/master/graph/badge.svg)](https://codecov.io/gh/alanmcruickshank/sqlfluff)
+[![Requirements Status](https://requires.io/github/alanmcruickshank/sqlfluff/requirements.svg?branch=master)](https://requires.io/github/alanmcruickshank/sqlfluff/requirements/?branch=master)
 [![CircleCI](https://circleci.com/gh/alanmcruickshank/sqlfluff/tree/master.svg?style=svg)](https://circleci.com/gh/alanmcruickshank/sqlfluff/tree/master)
 
 

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -82,7 +82,8 @@ def lint(verbose, nocolor, dialect, rules, paths):
     result = lnt.lint_paths(paths)
     # Output the results
     output = format_linting_result(result, verbose=verbose)
-    click.echo(output, color=color)
+    # Echo the output out, without adding a newline
+    click.echo(output, color=color, nl=False)
     sys.exit(result.stats()['exit code'])
 
 

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -118,14 +118,16 @@ def fix(verbose, nocolor, dialect, rules, force, paths):
         ))
         if force:
             click.echo('FORCE MODE: Attempting fixes...')
-            click.echo(format_linting_fixes(result, verbose=verbose), color=color)
+            fixes = result.fix()
+            click.echo(format_linting_fixes(fixes, verbose=verbose), color=color)
             click.echo('Done. Please check your files to confirm.')
         else:
             click.echo('Are you sure you wish to attempt to fix these? [Y/n] ', nl=False)
             c = click.getchar()
             if c == 'Y':
                 click.echo('Attempting fixes...')
-                click.echo(format_linting_fixes(result, verbose=verbose), color=color)
+                fixes = result.fix()
+                click.echo(format_linting_fixes(fixes, verbose=verbose), color=color)
                 click.echo('Done. Please check your files to confirm.')
             elif c == 'n':
                 click.echo('Aborting...')

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -104,20 +104,18 @@ def format_linting_violations(result, verbose=0):
     return text_buffer.getvalue()
 
 
-def format_linting_fixes(result, verbose=0):
-    """ Assume we're passed a LintingResult """
+def format_linting_fixes(fixes, verbose=0):
+    """ Assume we're passed a dict of fix results """
     text_buffer = StringIO()
-    for path in result.paths:
-        if path.num_violations() > 0:
-            text_buffer.write('=== [ path: {0} ] ===\n'.format(colorize(path.path, 'lightgrey')))
-            for file in path.files:
-                if file.num_violations() > 0:
-                    fixes, success = file.fixes()
-                    text_buffer.write(format_filename(file.path, success=success, verbose=verbose, success_text='FIXED'))
-                    text_buffer.write('\n')
-                    for fix in fixes:
-                        text_buffer.write(format_fix(fix, verbose=verbose))
-                        text_buffer.write('\n')
+    for file in fixes:
+        if len(fixes[file]) > 0:
+            fix_buff = fixes[file]
+            success = all([fix.success for fix in fix_buff])
+            text_buffer.write(format_filename(file, success=success, verbose=verbose, success_text='FIXED'))
+            text_buffer.write('\n')
+            for fix in fix_buff:
+                text_buffer.write(format_fix(fix, verbose=verbose))
+                text_buffer.write('\n')
     return text_buffer.getvalue()
 
 

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -64,11 +64,7 @@ def format_violations(violations, verbose=0):
             for violation in s:
                 text_buffer.write(format_violation(violation, verbose=verbose))
                 text_buffer.write('\n')
-    str_buffer = text_buffer.getvalue()
-    # Remove the trailing newline if there is one
-    if len(str_buffer) > 0 and str_buffer[-1] == '\n':
-        str_buffer = str_buffer[:-1]
-    return str_buffer
+    return text_buffer.getvalue()
 
 
 def format_linting_stats(result, verbose=0):
@@ -101,7 +97,12 @@ def format_linting_violations(result, verbose=0):
         if verbose > 0:
             text_buffer.write('=== [ path: {0} ] ===\n'.format(colorize(path.path, 'lightgrey')))
         text_buffer.write(format_violations(path.violations(), verbose=verbose))
-    return text_buffer.getvalue()
+
+    str_buffer = text_buffer.getvalue()
+    # Remove the trailing newline if there is one
+    if len(str_buffer) > 0 and str_buffer[-1] == '\n':
+        str_buffer = str_buffer[:-1]
+    return str_buffer
 
 
 def format_linting_fixes(fixes, verbose=0):

--- a/src/sqlfluff/cli/helpers.py
+++ b/src/sqlfluff/cli/helpers.py
@@ -1,6 +1,5 @@
 """ CLI helper utilities """
 
-from __future__ import unicode_literals
 from six import StringIO
 import sys
 import textwrap
@@ -9,10 +8,11 @@ from .. import __version__ as pkg_version
 
 
 color_lookup = {
-    'red': "\u001b[31m",
-    'green': "\u001b[32m",
-    'blue': "\u001b[36m",
-    'lightgrey': "\u001b[30;1m",
+    # Unicode literals here are important for PY2
+    'red': u"\u001b[31m",
+    'green': u"\u001b[32m",
+    'blue': u"\u001b[36m",
+    'lightgrey': u"\u001b[30;1m",
 }
 
 
@@ -20,7 +20,7 @@ color_lookup = {
 def colorize(s, color=None):
     if color:
         start_tag = color_lookup[color]
-        end_tag = "\u001b[0m"
+        end_tag = u"\u001b[0m"
         return start_tag + s + end_tag
     else:
         return s

--- a/src/sqlfluff/cli/helpers.py
+++ b/src/sqlfluff/cli/helpers.py
@@ -1,5 +1,6 @@
 """ CLI helper utilities """
 
+from __future__ import unicode_literals
 from six import StringIO
 import sys
 import textwrap

--- a/src/sqlfluff/config.ini
+++ b/src/sqlfluff/config.ini
@@ -1,3 +1,3 @@
 # Config file for sqlfluff, mostly for version info for now
 [sqlfluff]
-version=0.0.7
+version=0.0.8

--- a/src/sqlfluff/config.ini
+++ b/src/sqlfluff/config.ini
@@ -1,3 +1,3 @@
 # Config file for sqlfluff, mostly for version info for now
 [sqlfluff]
-version=0.0.8
+version=0.0.9

--- a/src/sqlfluff/config.ini
+++ b/src/sqlfluff/config.ini
@@ -1,3 +1,3 @@
 # Config file for sqlfluff, mostly for version info for now
 [sqlfluff]
-version=0.0.9
+version=0.0.8

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -155,6 +155,19 @@ class L008(BaseRule):
         return False
 
     @staticmethod
+    def correction_func(c, m):
+        cm1 = m.get('cm1', None)
+        if cm1.context != 'whitespace':
+            # Just add some whitespace
+            return cm1.correct(' ' + cm1.chunk)
+        else:
+            # It is whitespace, just the wrong amount
+            if '\n' in cm1.chunk:
+                return cm1.correct('\n')
+            else:
+                return cm1.correct(' ')
+
+    @staticmethod
     def memory_func(c, m):
         # Store the last three chunks
         return dict(

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -133,6 +133,9 @@ def generic_roundtrip_test(source_file, rulestring):
         for line in source_file:
             dest_file.write(line)
     runner = CliRunner()
+    # Check that we first detect the issue
+    result = runner.invoke(lint, ['--rules', rulestring, filepath])
+    assert result.exit_code == 65
     # Fix the file (in force mode)
     result = runner.invoke(fix, ['--rules', rulestring, '-f', filepath])
     assert result.exit_code == 0

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -3,7 +3,7 @@
 import configparser
 import tempfile
 import os
-import six
+import shutil
 
 from click.testing import CliRunner
 
@@ -122,23 +122,39 @@ def test__cli__command_rules():
     assert result.exit_code == 0
 
 
+def generic_roundtrip_test(source_file, rulestring):
+    """ A test for roundtrip testing, take a file buffer, lint, fix and lint """
+    filename = 'tesing.sql'
+    # Lets get the path of a file to use
+    tempdir_path = tempfile.mkdtemp()
+    filepath = os.path.join(tempdir_path, filename)
+    # Open the example file and write the content to it
+    with open(filepath, mode='w') as dest_file:
+        for line in source_file:
+            dest_file.write(line)
+    runner = CliRunner()
+    # Fix the file (in force mode)
+    result = runner.invoke(fix, ['--rules', rulestring, '-f', filepath])
+    assert result.exit_code == 0
+    # Now lint the file and check for exceptions
+    result = runner.invoke(lint, ['--rules', rulestring, filepath])
+    assert result.exit_code == 0
+    shutil.rmtree(tempdir_path)
+
+
 def test__cli__command__fix_L001():
     """ Test the round trip of detecting, fixing and then not detecting rule L001 """
-    # This test only runs in PY3
-    if six.PY3:
-        filename = 'tesing.sql'
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            filepath = os.path.join(tmpdirname, filename)
-            # Open the example file and write the content to it
-            with open('test/fixtures/linter/indentation_errors.sql', mode='r') as source_file:
-                with open(filepath, mode='w') as dest_file:
-                    for line in source_file:
-                        dest_file.write(line)
-            runner = CliRunner()
-            # Fix the file (in force mode)
-            result = runner.invoke(fix, ['--rules', 'L001', '-f', filepath])
-            assert result.exit_code == 0
+    with open('test/fixtures/linter/indentation_errors.sql', mode='r') as f:
+        generic_roundtrip_test(f, 'L001')
 
-            # Now lint the file and check for exceptions
-            result = runner.invoke(lint, ['--rules', 'L001', filepath])
-            assert result.exit_code == 0
+
+def test__cli__command__fix_L008_a():
+    """ Test the round trip of detecting, fixing and then not detecting rule L001 """
+    with open('test/fixtures/linter/whitespace_errors.sql', mode='r') as f:
+        generic_roundtrip_test(f, 'L008')
+
+
+def test__cli__command__fix_L008_b():
+    """ Test the round trip of detecting, fixing and then not detecting rule L001 """
+    with open('test/fixtures/linter/indentation_errors.sql', mode='r') as f:
+        generic_roundtrip_test(f, 'L008')

--- a/test/cli_formatters_test.py
+++ b/test/cli_formatters_test.py
@@ -57,5 +57,5 @@ def test__cli__formatters__violations():
     chk2 = []
     for elem in k:
         chk2 = chk2 + [format_filename(elem)] + chk[elem]
-    chk2 = '\n'.join(chk2)
+    chk2 = '\n'.join(chk2) + '\n'
     assert escape_ansi(f) == escape_ansi(chk2)

--- a/test/cli_formatters_test.py
+++ b/test/cli_formatters_test.py
@@ -1,7 +1,6 @@
 """ The Test file for CLI Formatters """
 
 import re
-import six
 
 from sqlfluff.chunks import PositionedChunk
 from sqlfluff.rules.base import RuleViolation, RuleGhost

--- a/test/cli_formatters_test.py
+++ b/test/cli_formatters_test.py
@@ -10,12 +10,7 @@ from sqlfluff.cli.formatters import format_filename, format_violation, format_vi
 
 def escape_ansi(line):
     """ A helper function to remove ANSI color codes """
-    if six.PY2:
-        # (WORKS IN P27)
-        ansi_escape = re.compile(u'\\\\u001b\\[[0-9]+(;[0-9]+)?m', flags=re.UNICODE)
-    else:
-        # (WORKS IN P36)
-        ansi_escape = re.compile(u'\u001b\\[[0-9]+(;[0-9]+)?m')
+    ansi_escape = re.compile(u'\u001b\\[[0-9]+(;[0-9]+)?m')
     return ansi_escape.sub('', line)
 
 
@@ -27,7 +22,7 @@ def test__cli__formatters__filename_nocol():
 def test__cli__formatters__filename_col():
     """ Explicity test color codes """
     res = format_filename('blah', success=False, verbose=0)
-    assert res == "== [\u001b[30;1mblah\u001b[0m] \u001b[31mFAIL\u001b[0m"
+    assert res == u"== [\u001b[30;1mblah\u001b[0m] \u001b[31mFAIL\u001b[0m"
 
 
 def test__cli__formatters__violation():

--- a/test/cli_helpers_test.py
+++ b/test/cli_helpers_test.py
@@ -4,7 +4,7 @@ from sqlfluff.cli.helpers import colorize, cli_table, wrap_elem, wrap_field, pad
 
 
 def test__cli__helpers__colorize():
-    assert colorize('foo', 'red') == "\u001b[31mfoo\u001b[0m"
+    assert colorize('foo', 'red') == u"\u001b[31mfoo\u001b[0m"
 
 
 def test__cli__helpers__cli_table():

--- a/test/linter_corrections_test.py
+++ b/test/linter_corrections_test.py
@@ -1,0 +1,13 @@
+""" The Test file for SQLFluff """
+
+from six import StringIO
+
+from sqlfluff.linter import LintedFile
+from sqlfluff.chunks import PositionedChunk, PositionedCorrection
+
+
+def test__linter__linted_file__apply_corrections_to_fileobj():
+    chunk = PositionedChunk('foofoofoo', 9, 2, None)
+    fo = StringIO("12345678\n123456789foofoofoo654fish\n1234567")
+    LintedFile.apply_corrections_to_fileobj(fo, [PositionedCorrection(chunk, 'bar')])
+    assert fo.getvalue() == "12345678\n123456789bar654fish\n1234567"

--- a/test/linter_test.py
+++ b/test/linter_test.py
@@ -114,3 +114,11 @@ def test__linter__linting_result__sum_dicts():
     assert lr.sum_dicts(a, b) == r
     # Check the identity too
     assert lr.sum_dicts(r, i) == r
+
+
+def test__linter__linting_result__combine_dicts():
+    lr = LintingResult()
+    a = dict(a=3, b=123, f=876.321)
+    b = dict(h=19, i=321.0, j=23478)
+    r = dict(z=22)
+    assert lr.combine_dicts(a, b, r) == dict(a=3, b=123, f=876.321, h=19, i=321.0, j=23478, z=22)

--- a/test/rules_std_roundtrip_test.py
+++ b/test/rules_std_roundtrip_test.py
@@ -1,0 +1,50 @@
+""" The Test file for CLI (General) """
+
+import tempfile
+import os
+import shutil
+
+from click.testing import CliRunner
+
+from sqlfluff.cli.commands import lint, fix
+
+
+def generic_roundtrip_test(source_file, rulestring):
+    """ A test for roundtrip testing, take a file buffer, lint, fix and lint """
+    filename = 'tesing.sql'
+    # Lets get the path of a file to use
+    tempdir_path = tempfile.mkdtemp()
+    filepath = os.path.join(tempdir_path, filename)
+    # Open the example file and write the content to it
+    with open(filepath, mode='w') as dest_file:
+        for line in source_file:
+            dest_file.write(line)
+    runner = CliRunner()
+    # Check that we first detect the issue
+    result = runner.invoke(lint, ['--rules', rulestring, filepath])
+    assert result.exit_code == 65
+    # Fix the file (in force mode)
+    result = runner.invoke(fix, ['--rules', rulestring, '-f', filepath])
+    assert result.exit_code == 0
+    # Now lint the file and check for exceptions
+    result = runner.invoke(lint, ['--rules', rulestring, filepath])
+    assert result.exit_code == 0
+    shutil.rmtree(tempdir_path)
+
+
+def test__cli__command__fix_L001():
+    """ Test the round trip of detecting, fixing and then not detecting rule L001 """
+    with open('test/fixtures/linter/indentation_errors.sql', mode='r') as f:
+        generic_roundtrip_test(f, 'L001')
+
+
+def test__cli__command__fix_L008_a():
+    """ Test the round trip of detecting, fixing and then not detecting rule L001 """
+    with open('test/fixtures/linter/whitespace_errors.sql', mode='r') as f:
+        generic_roundtrip_test(f, 'L008')
+
+
+def test__cli__command__fix_L008_b():
+    """ Test the round trip of detecting, fixing and then not detecting rule L001 """
+    with open('test/fixtures/linter/indentation_errors.sql', mode='r') as f:
+        generic_roundtrip_test(f, 'L008')

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pytest-cov
 # Include any other steps necessary for testing below
 commands =
-    pytest -vv --cov --cov-report=xml --junitxml=.test-reports/{envname}/junit.xml
+    pytest -vv --cov --cov-report=xml --junitxml=.test-reports/junit.xml
 setenv =
     COVERAGE_FILE = .coverage.{envname}
 


### PR DESCRIPTION
* Make sure the paths end up on separate lines in the output of linting
  errors.

* This means that violations will be formatted as a self-sustainable
  block (with a newline at the end).


Signed-off-by: mr.Shu <mr@shu.io>

----------------------------------------------

Hey @alanmcruickshank, I am not sure if the tests will pass on this one, but here is what I was trying to fix:

On `master` branch:

```
test/fixtures/linter $ sqlfluff lint -n *
== [indentation_error_simple.sql] FAIL
L:   2 | P:   1 | L003 | Single indentation uses a number of spaces not a multiple of 4== [indentation_errors.sql] FAIL
L:   2 | P:   1 | L003 | Single indentation uses a number of spaces not a multiple of 4
L:   3 | P:   1 | L002 | Single indentation uses mixture of tabs and spaces
L:   3 | P:   1 | L003 | Single indentation uses a number of spaces not a multiple of 4
L:   4 | P:   1 | L002 | Single indentation uses mixture of tabs and spaces
L:   4 | P:  24 | L001 | Unnecessary trailing whitespace
L:   4 | P:  24 | L008 | Commas should be followed by a single whitespace, unless followed by a comment
L:   5 | P:   1 | L004 | A file cannot mix tab and space indentation== [operator_errors.sql] FAIL
L:   3 | P:  10 | L006 | Operators should be surrounded by a single space unless at the start/end of a line
L:   4 | P:   9 | L006 | Operators should be surrounded by a single space unless at the start/end of a line
L:   5 | P:   9 | L007 | Operators should be at the start of lines rather than the end== [whitespace_errors.sql] FAIL
L:   2 | P:   9 | L005 | Commas should not have whitespace directly before them
L:   3 | P:  12 | L008 | Commas should be followed by a single whitespace, unless followed by a comment
L:   4 | P:   1 | L005 | Commas should not have whitespace directly before them

```

On this branch:

```
test/fixtures/linter $ sqlfluff lint -n *
== [indentation_error_simple.sql] FAIL
L:   2 | P:   1 | L003 | Single indentation uses a number of spaces not a multiple of 4
== [indentation_errors.sql] FAIL
L:   2 | P:   1 | L003 | Single indentation uses a number of spaces not a multiple of 4
L:   3 | P:   1 | L002 | Single indentation uses mixture of tabs and spaces
L:   3 | P:   1 | L003 | Single indentation uses a number of spaces not a multiple of 4
L:   4 | P:   1 | L002 | Single indentation uses mixture of tabs and spaces
L:   4 | P:  24 | L001 | Unnecessary trailing whitespace
L:   4 | P:  24 | L008 | Commas should be followed by a single whitespace, unless followed by a comment
L:   5 | P:   1 | L004 | A file cannot mix tab and space indentation
== [operator_errors.sql] FAIL
L:   3 | P:  10 | L006 | Operators should be surrounded by a single space unless at the start/end of a line
L:   4 | P:   9 | L006 | Operators should be surrounded by a single space unless at the start/end of a line
L:   5 | P:   9 | L007 | Operators should be at the start of lines rather than the end
== [whitespace_errors.sql] FAIL
L:   2 | P:   9 | L005 | Commas should not have whitespace directly before them
L:   3 | P:  12 | L008 | Commas should be followed by a single whitespace, unless followed by a comment
L:   4 | P:   1 | L005 | Commas should not have whitespace directly before them
```

Please feel free to use this PR in whatever way suits you best.

Thanks!