### PR TITLE
Add stdin input for lint cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 # Ignore the Environment
 env
 .tox
+venv
 
 # Ignore coverage reports
 .coverage

--- a/DOCS.md
+++ b/DOCS.md
@@ -69,6 +69,8 @@ them on each command, they are documented here for brevity:
   - _Blank_. If you just call `sqlfluff lint` without a path specified
     if will be as though you passed the current working directory and
     will behave as per the above command.
+  - _Stdin_. A lone `-` character will tell `sqlfluff` to lint data passed via stdin.
+
 
 **Example responses:**
 

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -82,10 +82,12 @@ def lint(verbose, nocolor, dialect, rules, exclude_rules, paths):
     Linting SQL files:
 
         sqlfluff lint path/to/file.sql
+        sqlfluff lint directory/of/sql/files
 
-    Linting the same file via stdin (note the lone '-' character):
+    Linting a file via stdin (note the lone '-' character):
 
         cat path/to/file.sql | sqlfluff lint -
+        echo 'select col from tbl' | sqlfluff lint -
 
     """
     # Configure Color

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -88,7 +88,7 @@ def lint(verbose, nocolor, dialect, rules, exclude_rules, paths):
     Linting a file via stdin (note the lone '-' character):
 
         \b
-        cat path/to/file.sql | sqlfluff lint -  
+        cat path/to/file.sql | sqlfluff lint -
         echo 'select col from tbl' | sqlfluff lint -
 
     """

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -1,15 +1,15 @@
 """ Contains the CLI """
 
-import click
 import sys
 
+import click
 
 from ..dialects import dialect_selector
 from ..linter import Linter
-from .formatters import (format_linting_result, format_config, format_rules,
-                         format_linting_violations,
+from .formatters import (format_config, format_linting_result,
+                         format_linting_violations, format_rules,
                          format_violation)
-from .helpers import get_package_version, cli_table
+from .helpers import cli_table, get_package_version
 
 
 def common_options(f):
@@ -88,7 +88,11 @@ def lint(verbose, nocolor, dialect, rules, exclude_rules, paths):
     # Lint the paths
     if verbose > 1:
         click.echo("==== logging ====")
-    result = lnt.lint_paths(paths, verbosity=verbose)
+    # add stdin if specified via lone '-'
+    if ('-',) == paths:
+        result = lnt.lint_string(sys.stdin.read(), name='stdin', verbosity=verbose)
+    else:
+        result = lnt.lint_paths(paths, verbosity=verbose)
     # Output the results
     output = format_linting_result(result, verbose=verbose)
     click.echo(output, color=color)
@@ -115,7 +119,7 @@ def fix(verbose, nocolor, dialect, rules, exclude_rules, force, paths):
         sys.exit(1)
     # Lint the paths (not with the fix argument at this stage)
     result = lnt.lint_paths(paths)
-
+    
     if result.num_violations() > 0:
         click.echo("==== violations found ====")
         click.echo(format_linting_violations(result, verbose=verbose), color=color)

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -77,7 +77,17 @@ def rules(verbose, nocolor, dialect, rules, exclude_rules):
 @common_options
 @click.argument('paths', nargs=-1)
 def lint(verbose, nocolor, dialect, rules, exclude_rules, paths):
-    """ Lint SQL files """
+    """Lint SQL files via passing a list of files or using stdin.
+
+    Linting SQL files:
+
+        sqlfluff lint path/to/file.sql
+
+    Linting the same file via stdin (note the lone '-' character):
+
+        cat path/to/file.sql | sqlfluff lint -
+
+    """
     # Configure Color
     color = False if nocolor else None
     # Instantiate the linter

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -119,7 +119,7 @@ def fix(verbose, nocolor, dialect, rules, exclude_rules, force, paths):
         sys.exit(1)
     # Lint the paths (not with the fix argument at this stage)
     result = lnt.lint_paths(paths)
-    
+
     if result.num_violations() > 0:
         click.echo("==== violations found ====")
         click.echo(format_linting_violations(result, verbose=verbose), color=color)

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -81,12 +81,14 @@ def lint(verbose, nocolor, dialect, rules, exclude_rules, paths):
 
     Linting SQL files:
 
+        \b
         sqlfluff lint path/to/file.sql
         sqlfluff lint directory/of/sql/files
 
     Linting a file via stdin (note the lone '-' character):
 
-        cat path/to/file.sql | sqlfluff lint -
+        \b
+        cat path/to/file.sql | sqlfluff lint -  
         echo 'select col from tbl' | sqlfluff lint -
 
     """

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -309,8 +309,16 @@ class Linter(object):
     def lint_string(self, string, name='<string input>', verbosity=0, fix=False):
         result = LintingResult(rule_whitelist=self.rule_whitelist)
         linted_path = LintedPath(name)
-        with StringIO(string) as f:
-            linted_path.add(self.lint_file(f, fname=name, verbosity=verbosity, fix=fix))
+        buf = StringIO(string)
+        try:
+            linted_path.add(
+                self.lint_file(buf, fname=name, verbosity=verbosity, fix=fix)
+            )
+        except Exception:
+            raise
+        finally:
+            buf.close()
+
         result.add(linted_path)
         return result
 

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -1,7 +1,6 @@
 """ Defines the linter class """
 
 import os
-import tempfile
 from collections import namedtuple
 
 from six import StringIO

--- a/src/sqlfluff/rules/crawler.py
+++ b/src/sqlfluff/rules/crawler.py
@@ -2,7 +2,7 @@
 
 # Crawlers, crawl through the trees returned by the parser and
 # evaluate particular rules.
-# The intent is that it should be possible for the rules to be epxressed
+# The intent is that it should be possible for the rules to be expressed
 # as simply as possible, with as much of the complexity abstracted away.
 
 # The evaluation function should take enough arguments that it can evaluate
@@ -15,7 +15,6 @@
 from collections import namedtuple
 
 from ..errors import SQLLintError
-
 
 # The ghost of a rule (mostly used for testing)
 RuleGhost = namedtuple('RuleGhost', ['code', 'description'])

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -1,8 +1,7 @@
 """ Standard SQL Linting Rules """
 
-from .crawler import BaseCrawler, LintResult, LintFix
 from ..parser import RawSegment
-
+from .crawler import BaseCrawler, LintFix, LintResult
 
 # TODO: Make this multiple configurable somewhere in
 # the dialect.

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -54,18 +54,20 @@ def test__cli__command_lint_a():
     result = runner.invoke(lint, ['-vv', 'test/fixtures/cli/passing_a.sql'])
     assert result.exit_code == 0
 
+
 @pytest.mark.parametrize('command', [
     ('-', '-n', ), ('-', '-n', '-v',), ('-', '-n', '-vv',), ('-', '-vv',),
 ])
 def test__cli__command_lint_stdin(command):
     """Check basic commands on a simple script using stdin.
-    
+
     The subprocess command should exit without errors, as no issues should be found.
     """
     sql = Path('test/fixtures/cli/passing_a.sql').read_text()
     runner = CliRunner()
     result = runner.invoke(lint, command, input=sql)
     assert result.exit_code == 0
+
 
 def test__cli__command_lint_b():
     """

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -4,7 +4,9 @@ import configparser
 import tempfile
 import os
 import shutil
+from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 import sqlfluff
@@ -35,7 +37,7 @@ def test__cli__command_dialect():
 def test__cli__command_lint_a():
     """
     Check basic commands on a simple script.
-    The subprocess command should exit without erros, as
+    The subprocess command should exit without errors, as
     no issues should be found.
     """
     runner = CliRunner()
@@ -52,6 +54,18 @@ def test__cli__command_lint_a():
     result = runner.invoke(lint, ['-vv', 'test/fixtures/cli/passing_a.sql'])
     assert result.exit_code == 0
 
+@pytest.mark.parametrize('command', [
+    ('-', '-n', ), ('-', '-n', '-v',), ('-', '-n', '-vv',), ('-', '-vv',),
+])
+def test__cli__command_lint_stdin(command):
+    """Check basic commands on a simple script using stdin.
+    
+    The subprocess command should exit without errors, as no issues should be found.
+    """
+    sql = Path('test/fixtures/cli/passing_a.sql').read_text()
+    runner = CliRunner()
+    result = runner.invoke(lint, command, input=sql)
+    assert result.exit_code == 0
 
 def test__cli__command_lint_b():
     """

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -4,7 +4,6 @@ import configparser
 import tempfile
 import os
 import shutil
-from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -63,7 +62,8 @@ def test__cli__command_lint_stdin(command):
 
     The subprocess command should exit without errors, as no issues should be found.
     """
-    sql = Path('test/fixtures/cli/passing_a.sql').read_text()
+    with open('test/fixtures/cli/passing_a.sql', 'r') as f:
+        sql = f.read()
     runner = CliRunner()
     result = runner.invoke(lint, command, input=sql)
     assert result.exit_code == 0

--- a/test/linter_test.py
+++ b/test/linter_test.py
@@ -60,7 +60,6 @@ def test__linter__lint_file_whitespace():
     assert not any([v[0] == 'L008' and v[1] == 4 for v in violations])
     assert not any([v[1] == 5 for v in violations])
 
-
 # def test__linter__lint_file_operators():
 #    lntr = Linter()
 #    lnt = lntr.lint_path('test/fixtures/linter/operator_errors.sql')
@@ -103,6 +102,39 @@ def test__linter__lint_file_whitespace():
 #    violations = lnt.check_tuples()
 #    # Check that this is allowed
 #    assert violations == []
+
+def test__linter__lint_string_indentation():
+    with open('test/fixtures/linter/indentation_errors.sql', 'r') as f:
+        sql = f.read()
+
+    lntr = Linter()
+    lnt = lntr.lint_string(sql)
+    violations = lnt.check_tuples()
+    # Check we get the trialing whitespace violation
+    assert ('L001', 4, 24) in violations
+    # Check we get the mixed indentation errors
+    assert ('L002', 3, 1) in violations
+    assert ('L002', 4, 1) in violations
+    # Check we get the space multiple violations
+    assert ('L003', 3, 1) in violations
+    # Check we get the mixed indentation errors between lines
+    assert ('L004', 5, 1) in violations
+
+
+def test__linter__lint_string_whitespace():
+    with open('test/fixtures/linter/whitespace_errors.sql', 'r') as f:
+        sql = f.read()
+    lntr = Linter()
+    lnt = lntr.lint_string(sql)
+    violations = lnt.check_tuples()
+    # Check we get comma (with leading space) whitespace errors
+    # assert ('L005', 2, 8) in violations
+    # assert ('L005', 4, 0) in violations
+    # Check we get comma (with incorrect trailing space) whitespace errors
+    assert ('L008', 3, 12) in violations
+    # Check for no false positives on line 4 or 5
+    assert not any([v[0] == 'L008' and v[1] == 4 for v in violations])
+    assert not any([v[1] == 5 for v in violations])
 
 
 def test__linter__linting_result__sum_dicts():


### PR DESCRIPTION
Mostly a request for feedback (I do not 100% understand the vision or even 10% understand the complexity of the codebase!). I'll work on tests, etc, if everyone likes the idea--

Basically the first thing i tried with sqlfluff was


```sh
echo 'select col from tbl' | sqlfluff lint
```

That didn't work so i tried using a `-` to specify stdin like:

```sh
echo 'select col from tbl' | sqlfluff lint -
```

And realized there is no sdtin functionality! I added a quick lint_string function and a cli handler. I don't know if stdin is in line with the sqlfluff vision, but thought it might be noted since it was literally the first thing i tried. I also attempted writing a fixer but was not sure how that would fit in with the rest of the cli (would it print the formatted string? What about the errors? etc). 

With these changes you can do

```sh
echo 'select col from tbl' | sqlfluff lint -
```

My first contrib so let me know if this is a use edge case and whether i should just save stdin to a darn file!