### PR TITLE
Functions, Parse Context and Bracket Matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
+
 - Added a `--exclude-rules` argument to most of the commands to allow rule users
   to exclude specific subset of rules, by [@sumitkumar1209](https://github.com/sumitkumar1209)
-- Added lexing for `!=` and `::`
+- Added lexing for `!=`, `~` and `::`.
+- Added a new common segment: `LambdaSegment` which allows matching based on arbitrary
+  functions which can be applied to segments.
+- Recursive Expressions for both arithmetic and functions, based heavily off the grammar
+  provided by the guys at [CockroachDB](https://www.cockroachlabs.com/docs/stable/sql-grammar.html#select_stmt).
+- An `Anything` grammar, useful in matching rather than in parsing to match anything.
+
+### Changed
+
+- Complete rewrite of the bracket counting functions, using some centralised class methods
+  on the `BaseGrammar` class to support common matching features across multiple grammars.
+  In particular this affects the `Delimited` grammar which is now *much simpler* but does
+  also require *slightly* more liberal use of terminators to match effectively.
+- Rather than passing around multiple variables during parsing and matching, there is now
+  a `ParseContext` object which contains things like the dialect and various depths. This
+  simplifies the parsing and matching code significantly.
+- Bracket referencing is now done from the dialect directly, rather than in individual
+  Grammars (except the `Bracketed` grammar, which still implements it directly). This
+  takes out some originally duplicated code.
+
+### Removed
+
+- Removed the `bracket_sensitive_forward_match` method from the `BaseGrammar`. It was ugly
+  and not flexible enough. It's been replaced by a suite of methods as described above.
 
 ## [0.1.3] - 2019-10-30
 

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -9,7 +9,7 @@ from .dialects import dialect_selector
 # TODO: I feel like these functions should live elsewhere, or
 # be importable directly from .parser
 from .parser.segments_file import FileSegment
-from .parser.segments_base import verbosity_logger, frame_msg
+from .parser.segments_base import verbosity_logger, frame_msg, ParseContext
 from .errors import SQLParseError, SQLLexError
 
 from .rules.std import standard_rule_set
@@ -192,7 +192,9 @@ class Linter(object):
         # Parse the file and log any problems
         if fs:
             try:
-                parsed = fs.parse(recurse=recurse, verbosity=verbosity, dialect=self.dialect)
+                # Make a parse context and parse
+                context = ParseContext(dialect=self.dialect, verbosity=verbosity, recurse=recurse)
+                parsed = fs.parse(parse_context=context)
             except SQLParseError as err:
                 violations.append(err)
                 parsed = None

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -8,12 +8,8 @@ from six import StringIO
 from .dialects import dialect_selector
 from .errors import SQLLexError, SQLParseError
 from .helpers import get_time
-from .parser.segments_base import frame_msg, verbosity_logger
-# TODO: I feel like these functions should live elsewhere, or
-# be importable directly from .parser
 from .parser.segments_file import FileSegment
 from .parser.segments_base import verbosity_logger, frame_msg, ParseContext
-from .errors import SQLParseError, SQLLexError
 from .rules.std import standard_rule_set
 
 

--- a/src/sqlfluff/parser/__init__.py
+++ b/src/sqlfluff/parser/__init__.py
@@ -3,6 +3,7 @@
 # flake8: noqa: F401
 
 from .segments_base import BaseSegment, RawSegment
-from .segments_common import KeywordSegment, ReSegment, NamedSegment
+from .segments_common import KeywordSegment, ReSegment, NamedSegment, LambdaSegment
 from .grammar import (Sequence, GreedyUntil, StartsWith, ContainsOnly,
-                      OneOf, Delimited, Bracketed, AnyNumberOf, Ref)
+                      OneOf, Delimited, Bracketed, AnyNumberOf, Ref,
+                      Anything)

--- a/src/sqlfluff/parser/grammar.py
+++ b/src/sqlfluff/parser/grammar.py
@@ -33,7 +33,7 @@ class BaseGrammar(object):
         # The optional attribute is set in the __init__ method
         return self.optional
 
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def match(self, segments, parse_context):
         """
             Matching can be done from either the raw or the segments.
             This raw function can be overridden, or a grammar defined
@@ -41,7 +41,7 @@ class BaseGrammar(object):
         """
         raise NotImplementedError("{0} has no match function implemented".format(self.__class__.__name__))
 
-    def _match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def _match(self, segments, parse_context):
         """ A wrapper on the match function to do some basic validation """
         t0 = get_time()
 
@@ -61,13 +61,12 @@ class BaseGrammar(object):
 
         # Work out the raw representation and curtail if long
         parse_match_logging(
-            parse_depth, match_depth, match_segment, self.__class__.__name__,
-            '_match', 'IN', verbosity=verbosity, v_level=self.v_level,
+            self.__class__.__name__, '_match', 'IN', parse_context=parse_context,
+            v_level=self.v_level,
             le=len(self._elements), ls=len(segments),
             seg=join_segments_raw_curtailed(segments))
 
-        m = self.match(segments, match_depth=match_depth, parse_depth=parse_depth,
-                       verbosity=verbosity, dialect=dialect, match_segment=match_segment)
+        m = self.match(segments, parse_context=parse_context)
 
         if not isinstance(m, MatchResult):
             logging.warning(
@@ -83,8 +82,8 @@ class BaseGrammar(object):
             msg = 'OUT'
 
         parse_match_logging(
-            parse_depth, match_depth, match_segment, self.__class__.__name__,
-            '_match', msg, verbosity=verbosity, v_level=self.v_level, dt=dt, m=m)
+            self.__class__.__name__, '_match', msg,
+            parse_context=parse_context, v_level=self.v_level, dt=dt, m=m)
 
         # Basic Validation
         check_still_complete(segments, m.matched_segments, m.unmatched_segments)
@@ -96,107 +95,260 @@ class BaseGrammar(object):
             "{0} does not implement expected_string!".format(
                 self.__class__.__name__))
 
-    @staticmethod
-    def bracket_sensitive_forward_match(segments, start_bracket, end_bracket,
-                                        match_depth, parse_depth, verbosity,
-                                        terminator=None, target=None, dialect=None,
-                                        match_segment=None):
-        sub_bracket_count = 0
-        unmatched_segs = segments
-        matched_segs = tuple()
-        current_bracket_segment = None
+    @classmethod
+    def _code_only_sensitive_match(cls, segments, matcher, parse_context, code_only=True):
+        """ A Kind of wrapped version of _match which deals with
+        non-code elements at the start and end """
+        if code_only:
+            seg_buff = segments
+            pre_ws = []
+            post_ws = []
+            # Trim whitespace at the start
+            while True:
+                if len(seg_buff) == 0:
+                    return MatchResult.from_unmatched(segments)
+                elif not seg_buff[0].is_code:
+                    pre_ws += [seg_buff[0]]
+                    seg_buff = seg_buff[1:]
+                else:
+                    break
+            # Trim whitespace at the end
+            while True:
+                if len(seg_buff) == 0:
+                    return MatchResult.from_unmatched(segments)
+                elif not seg_buff[-1].is_code:
+                    post_ws = [seg_buff[-1]] + post_ws
+                    seg_buff = seg_buff[:-1]
+                else:
+                    break
+            m = matcher._match(seg_buff, parse_context)
+            if m.is_complete():
+                # We need to do more to complete matches. It's complete so
+                # we don't need to worry about the unmatched.
+                return MatchResult.from_matched(tuple(pre_ws) + m.matched_segments + tuple(post_ws))
+            elif m:
+                # Incomplete matches, just get it added to the end of the unmatched
+                return MatchResult(
+                    matched_segments=tuple(pre_ws) + m.matched_segments,
+                    unmatched_segments=m.unmatched_segments + tuple(post_ws))
+            else:
+                # No match, just return unmatched
+                return MatchResult.from_unmatched(segments)
+        else:
+            # Code only not enabled, so just carry on
+            return matcher._match(segments, parse_context)
 
+    @classmethod
+    def _longest_code_only_sensitive_match(cls, segments, matchers, parse_context, code_only=True):
+        """ A wrapper around the code sensitive match to find the *best* match
+        from a selection of matchers.
+
+        Prioritise the first match, and if multiple match at the same point the longest.
+        If two matches of the same length match at the same time, then it's the first in
+        the iterable of matchers.
+
+        Return value is a tuple of (match_object, matcher)
+        """
+        # Do some type munging
+        matchers = list(matchers)
+        if isinstance(segments, BaseSegment):
+            segments = [segments]
+
+        # Have we been passed an empty list?
+        if len(segments) == 0:
+            return MatchResult.from_empty(), None
+
+        matches = []
+        # iterate at this position across all the matchers
+        for m in matchers:
+            res_match = cls._code_only_sensitive_match(
+                segments, m, parse_context=parse_context,
+                code_only=code_only)
+            if res_match.is_complete():
+                # Just return it! (WITH THE RIGHT OTHER STUFF)
+                return res_match, m
+            elif res_match:
+                # Add it to the buffer, make sure the buffer is processed
+                # and return the longest afterward.
+                matches.append((res_match, m))
+            else:
+                # Don't do much. Carry on.
+                pass
+
+        # If we get here, then there wasn't a complete match. Let's iterate
+        # through any other matches and return the longest if there is one.
+        if matches:
+            longest = None
+            for mat in matches:
+                if longest:
+                    # Compare the lengths of the matches
+                    if len(mat[0]) > len(longest[0]):
+                        longest = mat
+                else:
+                    longest = mat
+            return longest
+        else:
+            return MatchResult.from_unmatched(segments), None
+
+    @classmethod
+    def _look_ahead_match(cls, segments, matchers, parse_context, code_only=True):
+        """
+        Look ahead in a bracket sensitive way to find the next occurance of a particular
+        matcher(s). When a match is found, it is returned, along with any preceeding
+        (unmatched) segments, and a reference to the matcher which eventually matched it.
+
+        The intent is that this will become part of the bracket matching routines.
+
+        Prioritise the first match, and if multiple match at the same point the longest.
+        If two matches of the same length match at the same time, then it's the first in
+        the iterable of matchers.
+
+        Return value is a tuple of (unmatched_segments, match_object, matcher)
+        """
+        # Do some type munging
+        matchers = list(matchers)
+        if isinstance(segments, BaseSegment):
+            segments = [segments]
+
+        # Have we been passed an empty list?
+        if len(segments) == 0:
+            return ((), MatchResult.from_empty(), None)
+
+        # Make some buffers
+        seg_buff = segments
+        pre_seg_buff = ()  # NB: Tuple
+
+        # Loop
         while True:
-            # Are we at the end of the sequence?
-            if len(unmatched_segs) == 0:
-                # Yes we're at the end
+            # Do we have anything left to match on?
+            if seg_buff:
+                # Great, carry on.
+                pass
+            else:
+                # We've got to the end without a match, return empty
+                return ((), MatchResult.from_unmatched(segments), None)
 
-                # Are we in a bracket counting cycle that hasn't finished yet?
-                if sub_bracket_count > 0:
+            mat, m = cls._longest_code_only_sensitive_match(
+                seg_buff, matchers, parse_context=parse_context, code_only=code_only)
+
+            if mat:
+                return (pre_seg_buff, mat, m)
+            else:
+                # If there aren't any matches, then advance the buffer and try again.
+                pre_seg_buff += seg_buff[0],
+                seg_buff = seg_buff[1:]
+
+    @classmethod
+    def _bracket_sensitive_look_ahead_match(cls, segments, matchers, parse_context, code_only=True):
+        """
+        Same as above, the return value is a tuple of (unmatched_segments, match_object, matcher).
+        The difference is that under the hood it's also doing bracket counting.
+        """
+        # Type munging
+        matchers = list(matchers)
+        if isinstance(segments, BaseSegment):
+            segments = [segments]
+
+        # Have we been passed an empty list?
+        if len(segments) == 0:
+            return MatchResult.from_empty()
+
+        # Get hold of the bracket matchers from the dialect, and append them
+        # to the list of matchers.
+        start_bracket = parse_context.dialect.ref('StartBracketSegment')
+        end_bracket = parse_context.dialect.ref('EndBracketSegment')
+        bracket_matchers = [start_bracket, end_bracket]
+        matchers += bracket_matchers
+
+        # Make some buffers
+        seg_buff = segments
+        pre_seg_buff = ()  # NB: Tuple
+        bracket_stack = []
+
+        # Iterate
+        while True:
+            # Do we have anything left to match on?
+            if seg_buff:
+                # Yes we have buffer left to work with.
+                # Are we already in a bracket stack?
+                if bracket_stack:
+                    # Yes, we're just looking for the closing bracket, or
+                    # another opening bracket.
+                    pre, match, matcher = cls._look_ahead_match(
+                        seg_buff, bracket_matchers, parse_context=parse_context,
+                        code_only=code_only)
+
+                    if match:
+                        if matcher is start_bracket:
+                            # Same procedure as below in finding brackets.
+                            bracket_stack.append(match.matched_segments[0])
+                            pre_seg_buff += pre
+                            pre_seg_buff += match.matched_segments
+                            seg_buff = match.unmatched_segments
+                            continue
+                        elif matcher is end_bracket:
+                            # We've found an end bracket, remove it from the
+                            # stack and carry on.
+                            bracket_stack.pop()
+                            pre_seg_buff += pre
+                            pre_seg_buff += match.matched_segments
+                            seg_buff = match.unmatched_segments
+                            continue
+                        else:
+                            raise RuntimeError("I don't know how we get here?!")
+                    else:
+                        # No match and we're in a bracket stack. Raise an error
+                        raise SQLParseError(
+                            "Couldn't find closing bracket for opening bracket.",
+                            segment=bracket_stack.pop())
+                else:
+                    # No, we're open to more opening brackets or the thing(s)
+                    # that we're otherwise looking for.
+                    pre, match, matcher = cls._look_ahead_match(
+                        seg_buff, matchers, parse_context=parse_context,
+                        code_only=code_only)
+
+                    if match:
+                        if matcher is start_bracket:
+                            # We've found the start of a bracket segment.
+                            # NB: It might not *Actually* be the bracket itself,
+                            # but could be some non-code element preceeding it.
+                            # That's actually ok.
+
+                            # Add the bracket to the stack.
+                            bracket_stack.append(match.matched_segments[0])
+                            # Add the matched elements and anything before it to the
+                            # pre segment buffer. Reset the working buffer.
+                            pre_seg_buff += pre
+                            pre_seg_buff += match.matched_segments
+                            seg_buff = match.unmatched_segments
+                            continue
+                        elif matcher is end_bracket:
+                            # We've found an unexpected end bracket!
+                            raise SQLParseError(
+                                "Found unexpected end bracket!",
+                                segment=match.matched_segments[0])
+                        else:
+                            # It's one of the things we were looking for!
+                            # Return.
+                            return (pre_seg_buff + pre, match, matcher)
+                    else:
+                        # Not in a bracket stack, but no match. This is a happy
+                        # unmatched exit.
+                        return ((), MatchResult.from_unmatched(segments), None)
+            else:
+                # No we're at the end:
+                # Now check have we closed all our brackets?
+                if bracket_stack:
+                    # No we haven't.
                     # TODO: Format this better
                     raise SQLParseError(
                         "Couldn't find closing bracket for opening bracket.",
-                        segment=current_bracket_segment)
-
-                # TODO: Do something more intelligent here...
-                # Currently we just behave like we hit a terminator
-                return MatchResult(matched_segs, unmatched_segs)
-
-            else:
-                # Are we in a bracket cycle?
-                if sub_bracket_count > 0:
-                    # Yes we're in a bracket cycle. Ignore the other considerations.
-
-                    # Is it another bracket entry?
-                    bracket_match = start_bracket._match(
-                        segments=unmatched_segs, match_depth=match_depth + 1,
-                        parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                        match_segment=match_segment)
-                    if bracket_match.has_match():
-                        # increment the open bracket counter and proceed
-                        sub_bracket_count += 1
-                        # Not using indexing here allows the segments to mutate
-                        matched_segs += bracket_match.matched_segments
-                        unmatched_segs = bracket_match.unmatched_segments
-                        continue
-
-                    # Is it a closing bracket?
-                    bracket_match = end_bracket._match(
-                        segments=unmatched_segs, match_depth=match_depth + 1,
-                        parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                        match_segment=match_segment)
-                    if bracket_match.has_match():
-                        # reduce the bracket count and then advance the counter.
-                        sub_bracket_count -= 1
-                        # Not using indexing here allows the segments to mutate
-                        matched_segs += bracket_match.matched_segments
-                        unmatched_segs = bracket_match.unmatched_segments
-                        continue
-
+                        segment=bracket_stack.pop())
                 else:
-                    # No we're not in a bracket cycle.
-                    # Here we can either start a bracket cycle, find a target or find a terminator.
-
-                    # First look for a target if there is one.
-                    if target:
-                        target_match = target._match(
-                            unmatched_segs, match_depth=match_depth + 1,
-                            parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                            match_segment=match_segment)
-                        # Doesn't have to match fully, just has to give us a delimiter.
-                        if target_match.has_match():
-                            raise NotImplementedError("Still need to do this bit - maybe a callback")
-                    # Look for a terminator if there is one.
-                    if terminator:
-                        terminator_match = terminator._match(
-                            unmatched_segs, match_depth=match_depth + 1,
-                            parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                            match_segment=match_segment)
-                        # Doesn't have to match fully, just has to give us a delimiter.
-                        if terminator_match.has_match():
-                            # we've found a terminator.
-                            # TODO: We might need some kind of callback here to deal with the delimiter case
-                            return MatchResult(matched_segs, unmatched_segs)
-                    # Look for the start of a new bracket sequence
-                    bracket_match = start_bracket._match(
-                        segments=unmatched_segs, match_depth=match_depth + 1,
-                        parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                        match_segment=match_segment)
-                    if bracket_match.has_match():
-                        # increment the open bracket counter and proceed
-                        sub_bracket_count += 1
-                        # Keep track of this segment for error reporting
-                        current_bracket_segment = bracket_match.matched_segments[0]
-                        # Not using indexing here allows the segments to mutate
-                        matched_segs += bracket_match.matched_segments
-                        unmatched_segs = bracket_match.unmatched_segments
-                        continue
-                # Move onward. For the moment we're not fussy about what's in between
-                # as we're just looking for terminators or targets.
-                # TODO: configure this to allow rules around what can be here.
-                # For now, just assume if we've not matched it then it's good.
-                matched_segs += unmatched_segs[0],  # as tuple
-                unmatched_segs = unmatched_segs[1:]
+                    # We at the end but without a bracket left open. This is a
+                    # friendly unmatched return.
+                    return ((), MatchResult.from_unmatched(segments), None)
 
 
 class Ref(BaseGrammar):
@@ -223,17 +375,15 @@ class Ref(BaseGrammar):
         else:
             raise ReferenceError("No Dialect has been provided to Ref grammar!")
 
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
-        elem = self._get_elem(dialect=dialect)
+    def match(self, segments, parse_context):
+        elem = self._get_elem(dialect=parse_context.dialect)
 
         if elem:
             # Match against that. NB We're not incrementing the match_depth here.
             # References shouldn't relly count as a depth of match.
-            match_segment = self._get_ref()
             return elem._match(
-                segments=segments, match_depth=match_depth,
-                parse_depth=parse_depth, verbosity=verbosity,
-                dialect=dialect, match_segment=match_segment)
+                segments=segments,
+                parse_context=parse_context.copy(match_segment=self._get_ref()))
         else:
             raise ValueError("Null Element returned! _elements: {0!r}".format(self._elements))
 
@@ -256,6 +406,19 @@ class Ref(BaseGrammar):
             return elem.expected_string(dialect=dialect, called_from=called_from)
 
 
+class Anything(BaseGrammar):
+    """ See the match method desription for the full details """
+    def match(self, segments, parse_context):
+        """
+        Matches... Anything. Most useful in match grammars, where
+        a later parse grammmar will work out what's inside.
+        """
+        return MatchResult.from_matched(segments)
+
+    def expected_string(self, dialect=None, called_from=None):
+        return " <anything> "
+
+
 class OneOf(BaseGrammar):
     """ Match any of the elements given once, if it matches
     multiple, it returns the longest, and if any are the same
@@ -265,12 +428,14 @@ class OneOf(BaseGrammar):
         self.mode = kwargs.pop('mode', 'longest')  # can be 'first' or 'longest'
         super(OneOf, self).__init__(*args, **kwargs)
 
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def match(self, segments, parse_context):
         best_match = None
         # Match on each of the options
         for opt in self._elements:
-            m = opt._match(segments, match_depth=match_depth + 1, parse_depth=parse_depth,
-                           verbosity=verbosity, dialect=dialect, match_segment=match_segment)
+            m = opt._match(
+                segments,
+                parse_context=parse_context.copy(incr='match_depth')
+            )
             # If we get a complete match, just return it. If it's incomplete, then check to
             # see if it's all non-code if that allowed and match it
             if m.is_complete():
@@ -300,9 +465,9 @@ class OneOf(BaseGrammar):
                 else:
                     best_match = m
                 parse_match_logging(
-                    parse_depth, match_depth, match_segment, self.__class__.__name__,
+                    self.__class__.__name__,
                     '_match', "Saving Match of Length {0}:  {1}".format(len(m), m),
-                    verbosity=verbosity, v_level=self.v_level)
+                    parse_context=parse_context, v_level=self.v_level)
         else:
             # No full match from the first time round. If we've got a long partial match then return that.
             if best_match:
@@ -323,8 +488,7 @@ class OneOf(BaseGrammar):
                         break
                 # Now try and match
                 for opt in self._elements:
-                    m = opt._match(unmatched_segs, match_depth=match_depth + 1, parse_depth=parse_depth,
-                                   verbosity=verbosity, dialect=dialect, match_segment=match_segment)
+                    m = opt._match(unmatched_segs, parse_context=parse_context.copy(incr='match_depth'))
                     # Once again, if it's complete - return, if not wait to see if we get a more complete one
                     new_match = MatchResult(matched_segs + m.matched_segments, m.unmatched_segments)
                     if m.is_complete():
@@ -338,9 +502,9 @@ class OneOf(BaseGrammar):
                         else:
                             best_match = m
                         parse_match_logging(
-                            parse_depth, match_depth, match_segment, self.__class__.__name__,
+                            self.__class__.__name__,
                             '_match', "Last-Ditch: Saving Match of Length {0}:  {1}".format(len(m), m),
-                            verbosity=verbosity, v_level=self.v_level)
+                            parse_context=parse_context, v_level=self.v_level)
                 else:
                     if best_match:
                         return MatchResult(matched_segs + best_match.matched_segments, best_match.unmatched_segments)
@@ -363,7 +527,7 @@ class AnyNumberOf(BaseGrammar):
         # But also here, if min_times is zero then this is also optional
         return self.optional or self.min_times == 0
 
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def match(self, segments, parse_context):
         # Match on each of the options
         matched_segments = MatchResult.from_empty()
         unmatched_segments = segments
@@ -392,9 +556,10 @@ class AnyNumberOf(BaseGrammar):
 
             # Try the possibilities
             for opt in self._elements:
-                m = opt._match(unmatched_segments, match_depth=match_depth + 1,
-                               parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                               match_segment=match_segment)
+                m = opt._match(
+                    unmatched_segments,
+                    parse_context=parse_context.copy(incr='match_depth')
+                )
                 if m.has_match():
                     matched_segments += m.matched_segments
                     unmatched_segments = m.unmatched_segments
@@ -418,23 +583,21 @@ class AnyNumberOf(BaseGrammar):
 
 class GreedyUntil(BaseGrammar):
     """ See the match method desription for the full details """
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def match(self, segments, parse_context):
         """
         Matching for GreedyUntil works just how you'd expect.
         """
-        for idx, seg in enumerate(segments):
-            for opt in self._elements:
-                if opt._match(seg, match_depth=match_depth + 1, parse_depth=parse_depth,
-                              verbosity=verbosity, dialect=dialect, match_segment=match_segment):
-                    # We've matched something. That means we should return everything up to this point
-                    return MatchResult(segments[:idx], segments[idx:])
-                else:
-                    continue
+
+        pre, mat, _ = self._bracket_sensitive_look_ahead_match(
+            segments, self._elements, parse_context=parse_context.copy(incr='match_depth'),
+            code_only=self.code_only)
+
+        # Do we have a match?
+        if mat:
+            # Return everything up to the match
+            return MatchResult(pre, mat.all_segments())
         else:
-            # We've got to the end without matching anything, so return.
-            # We don't need to keep track of the match results, because
-            # if any of them were usable, then we wouldn't be returning
-            # anyway.
+            # Return everything
             return MatchResult.from_matched(segments)
 
     def expected_string(self, dialect=None, called_from=None):
@@ -446,7 +609,7 @@ class GreedyUntil(BaseGrammar):
 class Sequence(BaseGrammar):
     """ Match a specific sequence of elements """
 
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def match(self, segments, parse_context):
         # Rewrite of sequence. We should match FORWARD, this reduced duplication.
         # Sub-matchers should be greedy and so we can jsut work forward with each one.
         if isinstance(segments, BaseSegment):
@@ -480,9 +643,7 @@ class Sequence(BaseGrammar):
 
                     # It's not whitespace, so carry on to matching
                     elem_match = elem._match(
-                        unmatched_segments, match_depth=match_depth + 1,
-                        parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                        match_segment=match_segment)
+                        unmatched_segments, parse_context=parse_context.copy(incr='match_depth'))
 
                     if elem_match.has_match():
                         # We're expecting mostly partial matches here, but complete
@@ -541,27 +702,22 @@ class Delimited(BaseGrammar):
         self.terminator = kwargs.pop('terminator', None)
         # Setting min delimiters means we have to match at least this number
         self.min_delimiters = kwargs.pop('min_delimiters', None)
-
-        # The details on how to match a bracket are stored in the dialect
-        self.start_bracket = Ref('StartBracketSegment')
-        self.end_bracket = Ref('EndBracketSegment')
         super(Delimited, self).__init__(*args, **kwargs)
 
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def match(self, segments, parse_context):
+        # Type munging
         if isinstance(segments, BaseSegment):
             segments = [segments]
-        seg_idx = 0
-        terminal_idx = len(segments)
-        sub_bracket_count = 0
-        start_bracket_idx = None
-        # delimiters is a list of tuples (idx, len), which keeps track of where
-        # we found delimiters up to this point.
-        delimiters = []
-        matched_segments = MatchResult.from_empty()
 
         # Have we been passed an empty list?
         if len(segments) == 0:
             return MatchResult.from_empty()
+
+        # Make some buffers
+        seg_buff = segments
+        matched_segments = MatchResult.from_empty()
+        # delimiters is a list of tuples containing delimiter segments as we find them.
+        delimiters = []
 
         # First iterate through all the segments, looking for the delimiter.
         # Second, split the list on each of the delimiters, and ensure that
@@ -570,209 +726,113 @@ class Delimited(BaseGrammar):
         # In more detail, match against delimiter, if we match, put a slice
         # up to that point onto a list of slices. Carry on.
         while True:
-            # Are we at the end of the sequence?
-            if seg_idx >= terminal_idx:
-                # Yes we're at the end
-
-                # We now need to check whether everything from either the start
-                # or from the last delimiter up to here matches. We CAN allow
-                # a partial match at this stage.
-
-                # Are we in a bracket counting cycle that hasn't finished yet?
-                if sub_bracket_count > 0:
-                    # TODO: Format this better
-                    raise SQLParseError(
-                        "Couldn't find closing bracket for opening bracket.",
-                        segment=segments[start_bracket_idx])
-
-                # Do we already have any delimiters?
-                if delimiters:
-                    # Yes, get the last delimiter
-                    dm1 = delimiters[-1]
-                    # get everything after the last delimiter
-                    pre_segment = segments[dm1[0] + dm1[1]:terminal_idx]
+            # Check to see whether we've exhausted the buffer (or it's all non-code)
+            if len(seg_buff) == 0 or (self.code_only and all([not s.is_code for s in seg_buff])):
+                # Append the remaining buffer in case we're in the not is_code case.
+                matched_segments += seg_buff
+                # Nothing left, this is potentially a trailling case?
+                if self.allow_trailing and (self.min_delimiters is None or len(delimiters) >= self.min_delimiters):
+                    # It is! (nothing left so no unmatched segments to append)
+                    return matched_segments
                 else:
-                    # No, no delimiters at all so far.
-                    # TODO: Allow this to be configured.
-                    # Just get everything up to this point
-                    pre_segment = segments[:terminal_idx]
+                    MatchResult.from_unmatched(segments)
 
-                # Optionally here, we can match some non-code up front.
-                if self.code_only:
-                    while len(pre_segment) > 0:
-                        if not pre_segment[0].is_code:
-                            matched_segments += pre_segment[0],  # As tuple
-                            pre_segment = pre_segment[1:]
-                        else:
-                            break
+            # We rely on _bracket_sensitive_look_ahead_match to do the bracket counting
+            # element of this now. We look ahead to find a delimiter or terminator.
+            matchers = [self.delimiter]
+            if self.terminator:
+                matchers.append(self.terminator)
+            pre, mat, m = self._bracket_sensitive_look_ahead_match(
+                seg_buff, matchers, parse_context=parse_context.copy(incr='match_depth'),
+                # NB: We don't want whitespace at this stage, that should default to
+                # being passed to the elements in between.
+                code_only=False)
 
-                # Check we actually have something left to match on
-                if len(pre_segment) > 0:
-                    # See if any of the elements match
+            # Have we found a delimiter or terminator looking forward?
+            if mat:
+                if m is self.delimiter:
+                    # Yes. Store it and then match the contents up to now.
+                    delimiters.append(mat.matched_segments)
+                # We now test the intervening section as to whether it matches one
+                # of the things we're looking for. NB: If it's of zero length then
+                # we return without trying it.
+                if len(pre) > 0:
                     for elem in self._elements:
-                        elem_match = elem._match(
-                            pre_segment, match_depth=match_depth + 1,
-                            parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                            match_segment=match_segment)
+                        # We use the whitespace padded match to hoover up whitespace if enabled.
+                        elem_match = self._code_only_sensitive_match(
+                            pre, elem, parse_context=parse_context.copy(incr='match_depth'),
+                            # This is where the configured code_only behaviour kicks in.
+                            code_only=self.code_only)
 
-                        if elem_match.has_match():
-                            # Successfully matched one of the elements in this spot
+                        if elem_match.is_complete():
+                            # First add the segment up to the delimiter to the matched segments
+                            matched_segments += elem_match
+                            # Then it depends what we matched.
+                            # Delimiter
+                            if m is self.delimiter:
+                                # Then add the delimiter to the matched segments
+                                matched_segments += mat.matched_segments
+                                # Break this for loop and move on, looking for the next delimiter
+                                seg_buff = mat.unmatched_segments
+                                # Still got some buffer left. Carry on.
+                                break
+                            # Terminator
+                            elif m is self.terminator:
+                                # We just return straight away here. We don't add the terminator to
+                                # this match, it should go with the unmatched parts.
 
-                            # Add this match onto any already matched segments and return.
-                            # We do this in a slightly odd way here to allow partial matches.
-
-                            # we do a quick check on min_delimiters if present
-                            if self.min_delimiters and len(delimiters) < self.min_delimiters:
-                                # if we do have a limit and we haven't met it then crash out
-                                return MatchResult.from_unmatched(segments)
-                            return MatchResult(
-                                matched_segments.matched_segments + elem_match.matched_segments,
-                                elem_match.unmatched_segments + segments[terminal_idx:])
+                                # First check we've had enough delimiters
+                                if self.min_delimiters and len(delimiters) < self.min_delimiters:
+                                    return MatchResult.from_unmatched(segments)
+                                else:
+                                    return MatchResult(
+                                        matched_segments.matched_segments,
+                                        mat.all_segments())
+                            else:
+                                raise RuntimeError(
+                                    ("I don't know how I got here. Matched instead on {0}, which "
+                                     "doesn't appear to be delimiter or terminator").format(m))
                         else:
-                            # Not matched this element, move on.
-                            # NB, a partial match here isn't helpful. We're matching
-                            # BETWEEN two delimiters and so it must be a complete match.
-                            # Incomplete matches are only possible at the end
+                            # We REQUIRE a complete match here between delimiters or up to a
+                            # terminator. If it's only partial then we don't want it.
+                            # NB: using the sensitive match above deals with whitespace
+                            # appropriately.
                             continue
-
-                # If we're here we haven't matched any of the elements on this last element.
-                # BUT, if we allow trailing, and we have matched something, we can end on the last
-                # delimiter
-                if self.allow_trailing and len(matched_segments) > 0:
-                    return MatchResult(matched_segments.matched_segments, pre_segment + segments[terminal_idx:])
+                    else:
+                        # None of them matched, return unmatched.
+                        return MatchResult.from_unmatched(segments)
                 else:
+                    # Zero length section between delimiters. Return unmatched.
+                    return MatchResult.from_unmatched(segments)
+            else:
+                # No match for a delimiter looking forward, this means we're
+                # at the end. In this case we look for a potential partial match
+                # looking forward. We know it's a non-zero length section because
+                # we checked that up front.
+
+                # First check we're had enough delimiters, because if we haven't then
+                # there's no sense to try matching
+                if self.min_delimiters and len(delimiters) < self.min_delimiters:
                     return MatchResult.from_unmatched(segments)
 
-            else:
-                # We've got some sequence left.
-                # Are we in a bracket cycle?
-                if sub_bracket_count > 0:
-                    # Is it another bracket entry?
-                    bracket_match = self.start_bracket._match(
-                        segments=segments[seg_idx:], match_depth=match_depth + 1,
-                        parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                        match_segment=match_segment)
-                    if bracket_match.has_match():
-                        # increment the open bracket counter and proceed
-                        sub_bracket_count += 1
-                        seg_idx += len(bracket_match)
-                        continue
-
-                    # Is it a closing bracket?
-                    bracket_match = self.end_bracket._match(
-                        segments=segments[seg_idx:], match_depth=match_depth + 1,
-                        parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                        match_segment=match_segment)
-                    if bracket_match.has_match():
-                        # reduce the bracket count and then advance the counter.
-                        sub_bracket_count -= 1
-                        seg_idx += len(bracket_match)
-                        continue
-
+                # We use the whitespace padded match to hoover up whitespace if enabled,
+                # and default to the longest matcher. We don't care which one matches.
+                mat, _ = self._longest_code_only_sensitive_match(
+                    seg_buff, self._elements, parse_context=parse_context.copy(incr='match_depth'),
+                    code_only=self.code_only)
+                if mat:
+                    # We've got something at the end. Return!
+                    return MatchResult(
+                        matched_segments.matched_segments + mat.matched_segments,
+                        mat.unmatched_segments
+                    )
                 else:
-                    # No bracket cycle
-                    # Do we have a delimiter at the current index?
-
-                    del_match = self.delimiter._match(
-                        segments[seg_idx:], match_depth=match_depth + 1,
-                        parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                        match_segment=match_segment)
-
-                    # Doesn't have to match fully, just has to give us a delimiter.
-                    if del_match.has_match():
-                        # We've got at least a partial match
-                        # Record the location of this delimiter
-                        d = (seg_idx, len(del_match))
-                        # Do we already have any delimiters?
-                        if delimiters:
-                            # Yes
-                            dm1 = delimiters[-1]
-                            # slice the segments between this delimiter and the previous
-                            pre_segment = segments[dm1[0] + dm1[1]:d[0]]
-                        else:
-                            # No
-                            # Just get everything up to this point
-                            pre_segment = segments[:d[0]]
-                        # Append the delimiter that we have found.
-                        delimiters.append(d)
-
-                        # Optionally here, we can match some non-code up front.
-                        if self.code_only:
-                            while len(pre_segment) > 0:
-                                if not pre_segment[0].is_code:
-                                    matched_segments += pre_segment[0],  # As tuple
-                                    pre_segment = pre_segment[1:]
-                                else:
-                                    break
-
-                        # We now check that this chunk matches whatever we're delimiting.
-                        # In this case it MUST be a full match, not just a partial match
-                        for elem in self._elements:
-                            elem_match = elem._match(
-                                pre_segment, match_depth=match_depth + 1,
-                                parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                                match_segment=match_segment)
-
-                            if elem_match.is_complete():
-                                # Successfully matched one of the elements in this spot
-
-                                # First add the segment up to the delimiter to the matched segments
-                                matched_segments += elem_match
-                                # Then add the delimiter to the matched segments
-                                matched_segments += del_match
-                                # Break this for loop and move on, looking for the next delimiter
-                                seg_idx += len(del_match)
-                                break
-                            elif elem_match and self.code_only:
-                                # Optionally if it's not a complete match but the unmatched bits are
-                                # all non code then we'll also take it.
-                                if all([not seg.is_code for seg in elem_match.unmatched_segments]):
-                                    # Logic as above, just with the unmatched bits too because none are code
-                                    matched_segments += elem_match.matched_segments
-                                    matched_segments += elem_match.unmatched_segments
-                                    matched_segments += del_match
-                                    seg_idx += len(del_match)
-                                    break
-                                else:
-                                    continue
-                            else:
-                                # Not matched this element, move on.
-                                # NB, a partial match here isn't helpful. We're matching
-                                # BETWEEN two delimiters and so it must be a complete match.
-                                # Incomplete matches are only possible at the end
-                                continue
-                        else:
-                            # If we're here we haven't matched any of the elements, then we have a problem
-                            return MatchResult.from_unmatched(segments)
-                    # This index doesn't have a delimiter, check for brackets and terminators
-
-                    # First is it a terminator (and we're not in a bracket cycle)
-                    if self.terminator:
-                        term_match = self.terminator._match(
-                            segments[seg_idx:], match_depth=match_depth + 1,
-                            parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                            match_segment=match_segment)
-                        if term_match:
-                            # we've found a terminator.
-                            # End the cycle here.
-                            terminal_idx = seg_idx
-                            continue
-
-                    # Last, do we need to enter a bracket cycle
-                    bracket_match = self.start_bracket._match(
-                        segments=segments[seg_idx:], match_depth=match_depth + 1,
-                        parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                        match_segment=match_segment)
-                    if bracket_match.has_match():
-                        # increment the open bracket counter and proceed
-                        sub_bracket_count += 1
-                        seg_idx += len(bracket_match)
-                        continue
-
-                # Nothing else interesting. Carry On
-                # This is the same regardless of whether we're in the bracket cycle
-                # or otherwise.
-                seg_idx += 1
+                    # No match at the end, are we allowed to trail? If we are then return,
+                    # otherwise we fail because we can't match the last element.
+                    if self.allow_trailing:
+                        return MatchResult(matched_segments.matched_segments, seg_buff)
+                    else:
+                        return MatchResult.from_unmatched(segments)
 
     def expected_string(self, dialect=None, called_from=None):
         return " {0} ".format(
@@ -783,7 +843,7 @@ class Delimited(BaseGrammar):
 class ContainsOnly(BaseGrammar):
     """ match a sequence of segments which are only of the types,
     or only match the grammars in the list """
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def match(self, segments, parse_context):
         matched_buffer = tuple()
         forward_buffer = segments
         while True:
@@ -803,8 +863,7 @@ class ContainsOnly(BaseGrammar):
                             break
                     else:
                         m = opt._match(
-                            forward_buffer, match_depth=match_depth + 1, parse_depth=parse_depth,
-                            verbosity=verbosity, dialect=dialect, match_segment=match_segment)
+                            forward_buffer, parse_context=parse_context.copy(incr='match_depth'))
                         if m:
                             matched_buffer += m.matched_segments
                             forward_buffer = m.unmatched_segments
@@ -830,12 +889,9 @@ class StartsWith(BaseGrammar):
     def __init__(self, target, *args, **kwargs):
         self.target = target
         self.terminator = kwargs.pop('terminator', None)
-        # The details on how to match a bracket are stored in the dialect
-        self.start_bracket = Ref('StartBracketSegment')
-        self.end_bracket = Ref('EndBracketSegment')
         super(StartsWith, self).__init__(*args, **kwargs)
 
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def match(self, segments, parse_context):
         if self.code_only:
             first_code_idx = None
             # Work through to find the first code segment...
@@ -849,9 +905,8 @@ class StartsWith(BaseGrammar):
                 return MatchResult.from_unmatched(segments)
 
             match = self.target._match(
-                segments=segments[first_code_idx:], match_depth=match_depth + 1,
-                parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                match_segment=match_segment)
+                segments=segments[first_code_idx:],
+                parse_context=parse_context.copy(incr='match_depth'))
             if match:
                 # The match will probably have returned a mutated version rather
                 # that the raw segment sent for matching. We need to reinsert it
@@ -871,28 +926,33 @@ class StartsWith(BaseGrammar):
 
                     # Given a set of segments, iterate through looking for
                     # a terminator.
-                    term_match = self.bracket_sensitive_forward_match(
-                        segments=trailing_segments,
-                        start_bracket=self.start_bracket,
-                        end_bracket=self.end_bracket,
-                        match_depth=match_depth,
-                        parse_depth=parse_depth,
-                        verbosity=verbosity,
-                        terminator=self.terminator,
-                        dialect=dialect,
-                        match_segment=match_segment
+                    res = self._bracket_sensitive_look_ahead_match(
+                        segments=trailing_segments, matchers=[self.terminator],
+                        parse_context=parse_context
                     )
+
+                    # Depending on whether we found a terminator or not we treat
+                    # the result slightly differently. If no terminator was found,
+                    # we just use the whole unmatched segment. If we did find one,
+                    # we match up until (but not including) that terminator.
+                    term_match = res[1]
+                    if term_match:
+                        m_tail = res[0]
+                        u_tail = term_match.all_segments()
+                    else:
+                        m_tail = term_match.unmatched_segments
+                        u_tail = ()
+
                     return MatchResult(
                         segments[:first_code_idx]
                         + match_segments
-                        + term_match.matched_segments,
-                        term_match.unmatched_segments,
+                        + m_tail,
+                        u_tail,
                     )
                 else:
                     return MatchResult.from_matched(
                         segments[:first_code_idx]
-                        + match.matched_segments
-                        + match.unmatched_segments)
+                        + match.all_segments())
             else:
                 return MatchResult.from_unmatched(segments)
         else:
@@ -913,7 +973,7 @@ class Bracketed(BaseGrammar):
         self.end_bracket = Ref('EndBracketSegment')
         super(Bracketed, self).__init__(*args, **kwargs)
 
-    def match(self, segments, match_depth=0, parse_depth=0, verbosity=0, dialect=None, match_segment=None):
+    def match(self, segments, parse_context):
         """ The match function for `bracketed` implements bracket counting. """
 
         # 1. work forwards to find the first bracket.
@@ -924,121 +984,46 @@ class Bracketed(BaseGrammar):
         #    If we never find it's partner then we return an empty match but should probably
         #    log a parsing warning, or error?
 
-        sub_bracket_count = 0
-        pre_content_segments = tuple()
-        unmatched_segs = segments
-        matched_segs = tuple()
-        current_bracket_segment = None
+        seg_buff = segments
+        matched_segs = ()
 
-        # Step 1. Find the first useful segment
-        # Work through to find the first code segment...
-        if self.code_only:
-            for idx, seg in enumerate(segments):
-                if seg.is_code:
-                    break
-                else:
-                    matched_segs += seg,
-                    unmatched_segs = unmatched_segs[1:]
-            else:
-                # We've trying to match on a sequence of segments which contain no code.
-                # That means this isn't a match.
-                return MatchResult.from_unmatched(segments)
-
-        # is it a bracket?
-        m = self.start_bracket._match(
-            segments=unmatched_segs, match_depth=match_depth + 1,
-            parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-            match_segment=match_segment)
-
-        if m.has_match():
-            # We've got the first bracket.
-            # Update the seg_idx by the length of the match
-            current_bracket_segment = m.matched_segments[0]
-            # No indexing to allow mutation
-            matched_segs += m.matched_segments
-            unmatched_segs = m.unmatched_segments
+        # Look for the first bracket
+        start_match = self._code_only_sensitive_match(
+            seg_buff, self.start_bracket,
+            parse_context=parse_context.copy(incr='match_depth'),
+            code_only=self.code_only)
+        if start_match:
+            seg_buff = start_match.unmatched_segments
         else:
-            # Whatever we have, it doesn't start with a bracket.
+            # Can't find the opening bracket. No Match.
             return MatchResult.from_unmatched(segments)
 
-        # Step 2: Bracket count forward to find it's pair
-        content_segments = tuple()
-        pre_content_segments = matched_segs
+        # Look for the closing bracket
+        pre, end_match, _ = self._bracket_sensitive_look_ahead_match(
+            segments=seg_buff, matchers=[self.end_bracket],
+            parse_context=parse_context, code_only=self.code_only
+        )
+        if not end_match:
+            raise SQLParseError(
+                "Couldn't find closing bracket for opening bracket.",
+                segment=matched_segs)
 
-        while True:
-            # Are we at the end of the sequence?
-            if len(unmatched_segs) == 0:
-                # We've got to the end without finding the closing bracket
-                # this isn't just parsing issue this is probably a syntax
-                # error.
-                # TODO: Format this better
-                raise SQLParseError(
-                    "Couldn't find closing bracket for opening bracket.",
-                    segment=current_bracket_segment)
+        # Match the content now we've confirmed the brackets. We use the
+        # _longest helper function mostly just because it deals with multiple
+        # matchers.
+        content_match, _ = self._longest_code_only_sensitive_match(
+            pre, self._elements,
+            parse_context=parse_context.copy(incr='match_depth'),
+            code_only=self.code_only)
 
-            # Is it a closing bracket?
-            m = self.end_bracket._match(
-                segments=unmatched_segs, match_depth=match_depth + 1,
-                parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                match_segment=match_segment)
-            if m.has_match():
-                if sub_bracket_count == 0:
-                    # We're back to the bracket pair!
-                    matched_segs += m.matched_segments
-                    unmatched_segs = m.unmatched_segments
-                    closing_bracket_segs = m.matched_segments
-                    break
-                else:
-                    # reduce the bracket count and then advance the counter.
-                    sub_bracket_count -= 1
-                    matched_segs += m.matched_segments
-                    unmatched_segs = m.unmatched_segments
-                    continue
-
-            # Is it an opening bracket?
-            m = self.start_bracket._match(
-                segments=unmatched_segs, match_depth=match_depth + 1,
-                parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                match_segment=match_segment)
-            if m.has_match():
-                # increment the open bracket counter and proceed
-                sub_bracket_count += 1
-                matched_segs += m.matched_segments
-                unmatched_segs = m.unmatched_segments
-                continue
-
-            # If we get here it's not an opening bracket or a closing bracket
-            # so we should carry on our merry way
-            matched_segs += unmatched_segs[0],
-            content_segments += unmatched_segs[0],
-            unmatched_segs = unmatched_segs[1:]
-
-        # If we get to here then we've found our closing bracket.
-        # Let's identify the section to match for our content matchers
-        # and then try it against each of them.
-
-        for elem in self._elements:
-            elem_match = elem._match(
-                content_segments, match_depth=match_depth + 1,
-                parse_depth=parse_depth, verbosity=verbosity, dialect=dialect,
-                match_segment=match_segment)
-            # Matches at this stage must be complete, because we've got nothing
-            # to do with any leftovers within the brackets.
-            if elem_match.is_complete():
-                # We're also returning the *mutated* versions from the sub-matcher
-                return MatchResult(
-                    pre_content_segments
-                    + elem_match.matched_segments
-                    + closing_bracket_segs,
-                    unmatched_segs)
-            else:
-                # Not matched this element, move on.
-                # NB, a partial match here isn't helpful. We're matching
-                # BETWEEN two delimiters and so it must be a complete match.
-                # Incomplete matches are only possible at the end
-                continue
+        # We require a complete match for the content (hopefully for obvious reasons)
+        if content_match.is_complete():
+            return MatchResult(
+                start_match.matched_segments
+                + content_match.matched_segments
+                + end_match.matched_segments,
+                end_match.unmatched_segments)
         else:
-            # If we're here we haven't matched any of the elements, then we have a problem
             return MatchResult.from_unmatched(segments)
 
     def expected_string(self, dialect=None, called_from=None):

--- a/src/sqlfluff/parser/lexer.py
+++ b/src/sqlfluff/parser/lexer.py
@@ -163,6 +163,7 @@ class Lexer(object):
             SingletonMatcher.from_shorthand("dot", ".", is_code=True),
             SingletonMatcher.from_shorthand("comma", ",", is_code=True),
             SingletonMatcher.from_shorthand("plus", "+", is_code=True),
+            SingletonMatcher.from_shorthand("tilde", "~", is_code=True),
             SingletonMatcher.from_shorthand("minus", "-", is_code=True),
             SingletonMatcher.from_shorthand("divide", "/", is_code=True),
             SingletonMatcher.from_shorthand("star", "*", is_code=True),

--- a/src/sqlfluff/parser/match.py
+++ b/src/sqlfluff/parser/match.py
@@ -35,6 +35,9 @@ class MatchResult(namedtuple('MatchResult', ['matched_segments', 'unmatched_segm
         else:
             return None
 
+    def all_segments(self):
+        return self.matched_segments + self.unmatched_segments
+
     def __len__(self):
         return len(self.matched_segments)
 

--- a/test/dialects_test.py
+++ b/test/dialects_test.py
@@ -10,6 +10,7 @@ import logging
 import os
 import oyaml
 
+from sqlfluff.parser.segments_base import ParseContext
 from sqlfluff.parser.segments_file import FileSegment
 from sqlfluff.dialects import dialect_selector
 
@@ -86,11 +87,12 @@ def test__dialect__ansi__base_file_parse(dialect, file, caplog):
     assert fs.raw == raw
     # Load the right dialect
     dia = dialect_selector(dialect)
+    context = ParseContext(dialect=dia)
     # Do the parse with lots of logging
     with caplog.at_level(logging.DEBUG):
         logging.debug("Pre-parse structure: {0}".format(fs.to_tuple(show_raw=True)))
         logging.debug("Pre-parse structure: {0}".format(fs.stringify()))
-        parsed = fs.parse(dialect=dia)  # Optional: set recurse=1 to limit recursion
+        parsed = fs.parse(parse_context=context)  # Optional: set recurse=1 to limit recursion
         logging.debug("Post-parse structure: {0}".format(fs.to_tuple(show_raw=True)))
         logging.debug("Post-parse structure: {0}".format(fs.stringify()))
     # Check we're all there.
@@ -108,11 +110,12 @@ def test__dialect__ansi__base_parse_struct(dialect, sqlfile, yamlfile, caplog):
     """ Some simple statements to check full parsing structure """
     # Load the right dialect
     dia = dialect_selector(dialect)
+    context = ParseContext(dialect=dia)
     # Load the SQL
     raw = load_file(dialect, sqlfile)
     fs = FileSegment.from_raw(raw)
     # Load the YAML
     res = load_struct(dialect, yamlfile)
     with caplog.at_level(logging.DEBUG):
-        parsed = fs.parse(dialect=dia)
+        parsed = fs.parse(parse_context=context)
     assert parsed.to_tuple(code_only=True, show_raw=True) == res

--- a/test/fixtures/parser/ansi/functions_a.sql
+++ b/test/fixtures/parser/ansi/functions_a.sql
@@ -1,0 +1,4 @@
+SELECT
+    DATE(t), ROUND(b, 2),
+    LEFT(right(s, 5), LEN(s + 6)) as compound
+FROM tbl_b

--- a/test/fixtures/parser/ansi/functions_b.sql
+++ b/test/fixtures/parser/ansi/functions_b.sql
@@ -1,0 +1,4 @@
+-- Thanks @mrshu for this query, it tests nested functions
+SELECT
+    SPLIT(LOWER(text), ' ') AS text
+FROM "database"."sample_table"

--- a/test/fixtures/parser/ansi/select_simple_a.yml
+++ b/test/fixtures/parser/ansi/select_simple_a.yml
@@ -4,5 +4,4 @@ file:
       keyword: select
       select_target_group:
         select_target_element:
-          literal:
-            numeric_literal: 1
+          numeric_literal: 1

--- a/test/parser_grammar_test.py
+++ b/test/parser_grammar_test.py
@@ -4,9 +4,9 @@ import pytest
 import logging
 
 from sqlfluff.parser.grammar import (OneOf, Sequence, GreedyUntil, ContainsOnly,
-                                     Delimited)
+                                     Delimited, BaseGrammar)
 from sqlfluff.parser.markers import FilePositionMarker
-from sqlfluff.parser.segments_base import RawSegment
+from sqlfluff.parser.segments_base import RawSegment, ParseContext
 from sqlfluff.parser.segments_common import KeywordSegment
 from sqlfluff.dialects import ansi_dialect
 
@@ -23,6 +23,10 @@ def generate_test_segments(elems):
             cls = RawSegment.make(' ', name='whitespace')
         elif set(elem) <= set(['\n']):
             cls = RawSegment.make('\n', name='newline')
+        elif elem == "(":
+            cls = RawSegment.make("(", name='bracket_open', _is_code=True)
+        elif elem == ")":
+            cls = RawSegment.make(")", name='bracket_close', _is_code=True)
         elif elem.startswith('--'):
             cls = RawSegment.make('--', name='inline_comment')
         elif elem.startswith('"'):
@@ -47,14 +51,92 @@ def seg_list():
     return generate_test_segments(['bar', ' \t ', 'foo', 'baar', ' \t '])
 
 
+@pytest.fixture(scope="module")
+def bracket_seg_list():
+    return generate_test_segments([
+        'bar', ' \t ', '(', 'foo', '    ', ')', 'baar', ' \t ', 'foo'
+    ])
+
+
+def test__parser__grammar__base__code_only_sensitive_match(seg_list):
+    """ Test the _code_only_sensitive_match method of the BaseGrammar """
+    fs = KeywordSegment.make('foo')
+    bs = KeywordSegment.make('bar')
+    c = ParseContext()
+    # Matching the first element of the list
+    m = BaseGrammar._code_only_sensitive_match(seg_list, bs, c, code_only=False)
+    assert m.matched_segments == (bs('bar', seg_list[0].pos_marker),)
+    # Matching with a bit of whitespace before
+    m = BaseGrammar._code_only_sensitive_match(seg_list[1:], fs, c, code_only=True)
+    assert m.matched_segments == (seg_list[1], fs('foo', seg_list[2].pos_marker))
+    # Matching with a bit of whitespace before (not code_only)
+    m = BaseGrammar._code_only_sensitive_match(seg_list[1:], fs, c, code_only=False)
+    assert not m
+    # Matching with whitespace after
+    m = BaseGrammar._code_only_sensitive_match(seg_list[:2], bs, c, code_only=True)
+    assert m.matched_segments == (bs('bar', seg_list[0].pos_marker), seg_list[1])
+
+
+def test__parser__grammar__base__look_ahead_match(seg_list):
+    """ Test the _look_ahead_match method of the BaseGrammar """
+    fs = KeywordSegment.make('foo')
+    bs = KeywordSegment.make('bar')
+    c = ParseContext()
+
+    # Basic version, we should find bar first
+    m = BaseGrammar._look_ahead_match(seg_list, [fs, bs], c)
+    assert isinstance(m, tuple)
+    assert len(m) == 3
+    assert m[0] == ()
+    assert m[2] == bs
+    # NB the middle element is a match object
+    assert m[1].matched_segments == (bs('bar', seg_list[0].pos_marker),)
+
+    # Look ahead for foo
+    m = BaseGrammar._look_ahead_match(seg_list, [fs], c, code_only=False)
+    assert m[1].matched_segments == (fs('foo', seg_list[2].pos_marker),)
+
+    # Allow leading whitespace
+    m = BaseGrammar._look_ahead_match(seg_list, [fs], c, code_only=True)
+    assert m[1].matched_segments == (seg_list[1], fs('foo', seg_list[2].pos_marker))
+
+
+def test__parser__grammar__base__bracket_sensitive_look_ahead_match(bracket_seg_list):
+    """ Test the _bracket_sensitive_look_ahead_match method of the BaseGrammar """
+    fs = KeywordSegment.make('foo')
+    bs = KeywordSegment.make('bar')
+    # We need a dialect here to do bracket matching
+    c = ParseContext(dialect=ansi_dialect)
+
+    # Basic version, we should find bar first
+    m = BaseGrammar._bracket_sensitive_look_ahead_match(bracket_seg_list, [fs, bs], c)
+    assert isinstance(m, tuple)
+    assert len(m) == 3
+    assert m[0] == ()
+    assert m[2] == bs
+    # NB the middle element is a match object
+    assert m[1].matched_segments == (bs('bar', bracket_seg_list[0].pos_marker),)
+
+    # Look ahead for foo, we should find the one AFTER the brackets, not the
+    # on IN the brackets.
+    m = BaseGrammar._bracket_sensitive_look_ahead_match(bracket_seg_list, [fs], c)
+    assert isinstance(m, tuple)
+    assert len(m) == 3
+    assert len(m[0]) == 7  # NB: The bracket segments will have been mutated, so we can't directly compare
+    assert m[2] == fs
+    # We'll end up matching the whitespace with the keyword
+    assert m[1].matched_segments == (bracket_seg_list[7], fs('foo', bracket_seg_list[8].pos_marker))
+
+
 def test__parser__grammar_oneof(seg_list):
     fs = KeywordSegment.make('foo')
     bs = KeywordSegment.make('bar')
     g = OneOf(fs, bs, code_only=False)
+    c = ParseContext()
     # Check directly
-    assert g.match(seg_list).matched_segments == (bs('bar', seg_list[0].pos_marker),)
+    assert g.match(seg_list, parse_context=c).matched_segments == (bs('bar', seg_list[0].pos_marker),)
     # Check with a bit of whitespace
-    m = g.match(seg_list[1:])
+    m = g.match(seg_list[1:], parse_context=c)
     assert not m
 
 
@@ -62,11 +144,12 @@ def test__parser__grammar_oneof_codeonly(seg_list, caplog):
     fs = KeywordSegment.make('foo')
     bs = KeywordSegment.make('bar')
     g = OneOf(fs, bs)
+    c = ParseContext()
     with caplog.at_level(logging.DEBUG):
         # Check directly
-        assert g.match(seg_list).matched_segments == (bs('bar', seg_list[0].pos_marker), seg_list[1])
+        assert g.match(seg_list, parse_context=c).matched_segments == (bs('bar', seg_list[0].pos_marker), seg_list[1])
         # Check with a bit of whitespace
-        m = g.match(seg_list[1:])
+        m = g.match(seg_list[1:], parse_context=c)
         assert m
         assert m.matched_segments[1] == fs('foo', seg_list[2].pos_marker)
 
@@ -76,10 +159,11 @@ def test__parser__grammar_sequence(seg_list, caplog):
     bs = KeywordSegment.make('bar')
     g = Sequence(bs, fs)
     gc = Sequence(bs, fs, code_only=False)
+    c = ParseContext()
     with caplog.at_level(logging.DEBUG):
         # Should be able to match the list using the normal matcher
         logging.info("#### TEST 1")
-        m = g.match(seg_list)
+        m = g.match(seg_list, parse_context=c)
         assert m
         assert len(m) == 3
         assert m.matched_segments == (
@@ -89,10 +173,10 @@ def test__parser__grammar_sequence(seg_list, caplog):
         )
         # Shouldn't with the code_only matcher
         logging.info("#### TEST 2")
-        assert not gc.match(seg_list)
+        assert not gc.match(seg_list, parse_context=c)
         # Shouldn't match even on the normal one if we don't start at the beginning
         logging.info("#### TEST 2")
-        assert not g.match(seg_list[1:])
+        assert not g.match(seg_list[1:], parse_context=c)
 
 
 def test__parser__grammar_sequence_nested(seg_list, caplog):
@@ -100,13 +184,14 @@ def test__parser__grammar_sequence_nested(seg_list, caplog):
     bs = KeywordSegment.make('bar')
     bas = KeywordSegment.make('baar')
     g = Sequence(Sequence(bs, fs), bas)
+    c = ParseContext()
     with caplog.at_level(logging.DEBUG):
         # Matching the start of the list shouldn't work
         logging.info("#### TEST 1")
-        assert not g.match(seg_list[:2])
+        assert not g.match(seg_list[:2], parse_context=c)
         # Matching the whole list should, and the result should be flat
         logging.info("#### TEST 2")
-        assert g.match(seg_list).matched_segments == (
+        assert g.match(seg_list, parse_context=c).matched_segments == (
             bs('bar', seg_list[0].pos_marker),
             seg_list[1],  # This will be the whitespace segment
             fs('foo', seg_list[2].pos_marker),
@@ -129,21 +214,21 @@ def test__parser__grammar_delimited(caplog):
     )
     g = Delimited(bs, delimiter=comma)
     gt = Delimited(bs, delimiter=comma, allow_trailing=True)
+    c = ParseContext(dialect=ansi_dialect)
     with caplog.at_level(logging.DEBUG):
         # Matching not quite the full list shouldn't work
         logging.info("#### TEST 1")
-        assert not g.match(seg_list[:4], dialect=ansi_dialect)
+        assert not g.match(seg_list[:4], parse_context=c)
         # Matching not quite the full list should work if we allow trailing
         logging.info("#### TEST 1")
-        assert gt.match(seg_list[:4], dialect=ansi_dialect)
+        assert gt.match(seg_list[:4], parse_context=c)
         # Matching up to 'bar' should
         logging.info("#### TEST 3")
-        assert g._match(seg_list[:5], dialect=ansi_dialect).matched_segments == expectation[:5]
+        assert g._match(seg_list[:5], parse_context=c).matched_segments == expectation[:5]
         # Matching the full list ALSO should, because it's just whitespace
         logging.info("#### TEST 4")
-        assert g.match(seg_list, dialect=ansi_dialect).matched_segments == expectation[:5]
-        # We shouldn't have matched the trailing whitespace.
-        # TODO: Check I actually mean this...
+        assert g.match(seg_list, parse_context=c).matched_segments == expectation[:6]
+        # We should have matched the trailing whitespace in this case.
 
 
 def test__parser__grammar_delimited_not_code_only(caplog):
@@ -152,14 +237,15 @@ def test__parser__grammar_delimited_not_code_only(caplog):
     bs = KeywordSegment.make('bar')
     dot = KeywordSegment.make('.', name='dot')
     g = Delimited(bs, delimiter=dot, code_only=False)
+    c = ParseContext(dialect=ansi_dialect)
     with caplog.at_level(logging.DEBUG):
         # Matching with whitespace shouldn't match
         # TODO: dots should be parsed out EARLY
         logging.info("#### TEST 1")
-        assert not g.match(seg_list_a, dialect=ansi_dialect)
+        assert not g.match(seg_list_a, parse_context=c)
         # Matching up to 'bar' should
         logging.info("#### TEST 2")
-        assert g.match(seg_list_b, dialect=ansi_dialect) is not None
+        assert g.match(seg_list_b, parse_context=c) is not None
 
 
 def test__parser__grammar_greedyuntil(seg_list):
@@ -169,14 +255,25 @@ def test__parser__grammar_greedyuntil(seg_list):
     bs = KeywordSegment.make('bar')
     bas = KeywordSegment.make('baar')
     g0 = GreedyUntil(bs)
-    g1 = GreedyUntil(fs)
+    g1 = GreedyUntil(fs, code_only=False)
     g2 = GreedyUntil(bas)
+    c = ParseContext(dialect=ansi_dialect)
     # Greedy matching until the first item should return none
-    assert not g0.match(seg_list)
+    assert not g0.match(seg_list, parse_context=c)
     # Greedy matching up to foo should return bar (as a raw!)
-    assert g1.match(seg_list).matched_segments == seg_list[:2]
+    assert g1.match(seg_list, parse_context=c).matched_segments == seg_list[:2]
     # Greedy matching up to baar should return bar, foo  (as a raw!)
-    assert g2.match(seg_list).matched_segments == seg_list[:3]
+    assert g2.match(seg_list, parse_context=c).matched_segments == seg_list[:3]
+
+
+def test__parser__grammar_greedyuntil_bracketed(bracket_seg_list):
+    """ NB Greedy until should NOT match if the until
+    segment is present at all """
+    fs = KeywordSegment.make('foo')
+    g = GreedyUntil(fs, code_only=False)
+    c = ParseContext(dialect=ansi_dialect)
+    # Check that we can make it past the brackets
+    assert len(g.match(bracket_seg_list, parse_context=c)) == 8
 
 
 def test__parser__grammar_containsonly(seg_list):
@@ -187,12 +284,13 @@ def test__parser__grammar_containsonly(seg_list):
     g1 = ContainsOnly('raw')
     g2 = ContainsOnly(fs, bas, bs)
     g3 = ContainsOnly(fs, bas, bs, code_only=False)
+    c = ParseContext()
     # Contains only, without matches for all shouldn't match
-    assert not g0.match(seg_list)
+    assert not g0.match(seg_list, parse_context=c)
     # Contains only, with just the type should return the list as is
-    assert g1.match(seg_list) == seg_list
+    assert g1.match(seg_list, parse_context=c) == seg_list
     # Contains only with matches for all should, as the matched versions
-    assert g2.match(seg_list).matched_segments == (
+    assert g2.match(seg_list, parse_context=c).matched_segments == (
         bs('bar', seg_list[0].pos_marker),
         seg_list[1],  # This will be the whitespace segment
         fs('foo', seg_list[2].pos_marker),
@@ -200,4 +298,4 @@ def test__parser__grammar_containsonly(seg_list):
         seg_list[4]  # This will be the whitespace segment
     )
     # When we consider mode than code then it shouldn't work
-    assert not g3.match(seg_list)
+    assert not g3.match(seg_list, parse_context=c)

--- a/test/parser_segments_base_test.py
+++ b/test/parser_segments_base_test.py
@@ -3,7 +3,7 @@
 import pytest
 
 from sqlfluff.parser.markers import FilePositionMarker
-from sqlfluff.parser.segments_base import RawSegment, BaseSegment
+from sqlfluff.parser.segments_base import RawSegment, BaseSegment, ParseContext
 from sqlfluff.dialects import ansi_dialect
 
 
@@ -58,10 +58,11 @@ def test__parser__base_segments_raw(raw_seg):
 
 def test__parser__base_segments_base(raw_seg_list):
     base_seg = DummySegment(raw_seg_list)
+    context = ParseContext(dialect=ansi_dialect)
     # Check we assume the position correctly
     assert base_seg.pos_marker == raw_seg_list[0].pos_marker
     # Expand and given we don't have a grammar we should get the same thing
-    assert base_seg.parse(dialect=ansi_dialect) == base_seg
+    assert base_seg.parse(parse_context=context) == base_seg
     # Check that we correctly reconstruct the raw
     assert base_seg.raw == "foobar.barfoo"
     # Check tuple

--- a/test/parser_segments_core_test.py
+++ b/test/parser_segments_core_test.py
@@ -4,7 +4,7 @@ import pytest
 
 
 from sqlfluff.parser.markers import FilePositionMarker
-from sqlfluff.parser.segments_base import RawSegment
+from sqlfluff.parser.segments_base import RawSegment, ParseContext
 from sqlfluff.parser.segments_common import KeywordSegment
 
 
@@ -30,22 +30,23 @@ def test__parser__core_keyword(raw_seg_list):
     """ Test the Mystical KeywordSegment """
     # First make a keyword
     FooKeyword = KeywordSegment.make('foo')
+    context = ParseContext()
     # Check it looks as expected
     assert issubclass(FooKeyword, KeywordSegment)
     assert FooKeyword.__name__ == "FOO_KeywordSegment"
     assert FooKeyword._template == 'FOO'
     # Match it against a list and check it doesn't match
-    assert not FooKeyword.match(raw_seg_list)
+    assert not FooKeyword.match(raw_seg_list, parse_context=context)
     # Match it against a the first element and check it doesn't match
-    assert not FooKeyword.match(raw_seg_list[0])
+    assert not FooKeyword.match(raw_seg_list[0], parse_context=context)
     # Match it against a the first element as a list and check it doesn't match
-    assert not FooKeyword.match([raw_seg_list[0]])
+    assert not FooKeyword.match([raw_seg_list[0]], parse_context=context)
     # Match it against the final element (returns tuple)
-    m = FooKeyword.match(raw_seg_list[1])
+    m = FooKeyword.match(raw_seg_list[1], parse_context=context)
     assert m
     assert m.matched_segments[0].raw == 'foo'
     assert isinstance(m.matched_segments[0], FooKeyword)
     # Match it against the final element as a list
-    assert FooKeyword.match([raw_seg_list[1]])
+    assert FooKeyword.match([raw_seg_list[1]], parse_context=context)
     # Match it against a list slice and check it still works
-    assert FooKeyword.match(raw_seg_list[1:])
+    assert FooKeyword.match(raw_seg_list[1:], parse_context=context)


### PR DESCRIPTION
Big refactor of parse context to make things easier.
New generic forward matching routines including centralised bracket counting.
Removed old bracket counting routines.
Replace the bracket counting in Delimited & GreedyUntil.
Introduce the LambdaSegment option.
Update Changelog.

NB: This closes #23 and part of #22 