### PR TITLE
Issue 41: Fix Python 2.7 installation issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import io
-import configparser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 from os.path import dirname
 from os.path import join
 
@@ -17,7 +20,7 @@ from setuptools import setup
 # Get the global config info as currently stated
 # (we use the config file to avoid actually loading any python here)
 config = configparser.ConfigParser()
-config.read_file(open('src/sqlfluff/config.ini'))
+config.read(['src/sqlfluff/config.ini'])
 version = config.get('sqlfluff', 'version')
 
 


### PR DESCRIPTION
This fixes the installation issue (#41) with Python 2.7. I have not manually tested on Python 3, but did read the Python 3 docs to confirm that the `read()` function is available in both Python 2.7 and Python 3. Hopefully the Tox automated tests will confirm this.

* [Python 2.7](https://docs.python.org/2/library/configparser.html#ConfigParser.RawConfigParser.read)
* [Python 3](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read)