### PR TITLE
Better docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Variables + Macros.
 - Config file support, including specifying context for the templater.
 - Documentation via Sphinx and readthedocs.
+  - Including a guide on the role of SQL in the real world.
+    Assisted by [@barrywhart](https://github.com/barrywhart).
 - Documentation LINTING (given we're a linting project) introduced in CI.
 - Reimplemented L006 & L007 which lint whitespace around operators.
-- Ability to configure rule behaviour direclty from the config file.
+- Ability to configure rule behaviour directly from the config file.
 
 ### Changed
 
@@ -131,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a `sqlfluff fix` as a command to implement auto-fixing of linting
   errors. For now only `L001` is implemented as a rule that can fix things.
-- Added a `rules` command to introspec the available rules.
+- Added a `rules` command to introspect the available rules.
 - Updated the cli table function to use the `testwrap` library and also
   deal a lot better with longer values.
 - Added a `--rules` argument to most of the commands to allow rule users
@@ -166,7 +168,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added operator regexes
-- Added a priority for matchers to resolve some abiguity
+- Added a priority for matchers to resolve some ambiguity
 - Added tests for operator regexes
 - Added ability to initialise the memory in rules
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,7 @@ Contents
    :maxdepth: 3
    :caption: Documentation for sqlfluff:
 
+   realworld
    rules
    configuration
    architecture

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
-The SQL Linter for humans
-=========================
+📜 ✒️ ✨ The SQL Linter for humans
+===================================
 
 Bored of not having a good SQL linter that works with whichever dialiect
 you're working with? Fluff is an extensible and modular linter designed

--- a/docs/source/realworld.rst
+++ b/docs/source/realworld.rst
@@ -1,7 +1,7 @@
 .. _realworldref:
 
-SQL in the Modern Data Stack
-============================
+SQL in the Wild
+===============
 
 SQL has been around for a long time, as a language for communicating
 with databases, like a communication protocol. More recently with the

--- a/docs/source/realworld.rst
+++ b/docs/source/realworld.rst
@@ -1,0 +1,89 @@
+.. _realworldref:
+
+SQL in the Modern Data Stack
+============================
+
+SQL has been around for a long time, as a language for communicating
+with databases, like a communication protocol. More recently with the
+rise of *data* as a business function, or a domain in it's own right
+SQL has also become an invaluable tool for defining the *structure* of
+data and analysis - not just as a one off but as a form of
+`infrastructure as code`_.
+
+As *analytics* transitions from a profession of people doing one-offs,
+and moves to building stable and reuable pieces of analytics, more and
+more principles from software engineering are moving in the analytics
+space. One of the best articulations of this is written in the
+`viewpoint section of the docs for the open-source tool dbt`_. Two of
+the principles mentioned in that article are `quality assurance`_ and
+`modularity`_.
+
+Quality assurance
+-----------------
+
+The primary aim of `sqlfluff` as a project is in service of that first
+aim of `quality assurance`_. With larger and larger teams maintaining
+large bodies of SQL code, it becomes more and more important that the
+code is not just *valid* but also easily *comprehendable* by other users
+of the same codebase. One way to ensure readability is to enfore a
+`consistent style`_, and the tools used to to this are called `linters`_.
+
+Some famous `linters`_ which are well known in the software community are
+`flake8`_ and `jslint`_ (the former is used to lint the `sqlfluff` project
+itself).
+
+**Sqlfluff** aims to fill this space for SQL.
+
+Modularity
+----------
+
+SQL itself doesn't lend itself well to `modularity`_, so to introduce
+some flexibility and reusability it is often `templated`_. Typically
+this is done in the wild in one of the following ways:
+
+1. Using the limited inbuilt templating abilities of a programming
+   language directly. For example in python this would be using the
+   `format string syntax`_:
+
+   .. code-block:: python
+
+      "SELECT {foo} FROM {tbl}".format(foo="bar", tbl="mytable")
+
+   Which would evaluate to:
+
+   .. code-block:: sql
+
+      SELECT bar FROM mytable
+
+2. Using a dedicated templating library such as `jinja2`_. This allows
+   a lot more flexibility and more powerful expressions and macros. See
+   the :ref:`templateconfig` section for more detail on how this works.
+
+   - Often there are tools like `dbt`_ or `apache airflow`_ which allow
+     `templated`_ sql to be used directly, and they will implement a
+     library like `jinja2`_ under the hood themselves.
+
+
+All of these templating tools are great for `modularity`_ but they also
+mean that the SQL files themselves are no longer valid SQL code, because
+they now contain these configured *placeholder* values, inteded to
+improve modularity.
+
+Sqlfluff allows limited templating using both of the methods outlined
+above, to allow you to still lint those SQL files as part of your CI/CD
+pipeline (which is great 🙌), rather than waiting until you're in production
+(which is bad 🤦, and maybe too late).
+
+.. _`infrastructure as code`: https://en.wikipedia.org/wiki/Infrastructure_as_code
+.. _`viewpoint section of the docs for the open-source tool dbt`: https://docs.getdbt.com/docs/viewpoint
+.. _`quality assurance`: https://docs.getdbt.com/docs/viewpoint#section-quality-assurance
+.. _`modularity`: https://docs.getdbt.com/docs/viewpoint#section-modularity
+.. _`consistent style`: https://www.smashingmagazine.com/2012/10/why-coding-style-matters/
+.. _`linters`: https://en.wikipedia.org/wiki/Lint_(software)
+.. _`flake8`: http://flake8.pycqa.org/
+.. _`jslint`: https://www.jslint.com/
+.. _`templated`: https://en.wikipedia.org/wiki/Template_processor
+.. _`format string syntax`: https://docs.python.org/3/library/string.html#formatstrings
+.. _`jinja2`: https://jinja.palletsprojects.com/
+.. _`apache airflow`: https://airflow.apache.org
+.. _`dbt`: https://getdbt.com

--- a/docs/source/realworld.rst
+++ b/docs/source/realworld.rst
@@ -11,7 +11,7 @@ data and analysis - not just as a one off but as a form of
 `infrastructure as code`_.
 
 As *analytics* transitions from a profession of people doing one-offs,
-and moves to building stable and reuable pieces of analytics, more and
+and moves to building stable and reusable pieces of analytics, more and
 more principles from software engineering are moving in the analytics
 space. One of the best articulations of this is written in the
 `viewpoint section of the docs for the open-source tool dbt`_. Two of
@@ -24,9 +24,9 @@ Quality assurance
 The primary aim of `sqlfluff` as a project is in service of that first
 aim of `quality assurance`_. With larger and larger teams maintaining
 large bodies of SQL code, it becomes more and more important that the
-code is not just *valid* but also easily *comprehendable* by other users
-of the same codebase. One way to ensure readability is to enfore a
-`consistent style`_, and the tools used to to this are called `linters`_.
+code is not just *valid* but also easily *comprehensible* by other users
+of the same codebase. One way to ensure readability is to enforce a
+`consistent style`_, and the tools used to do this are called `linters`_.
 
 Some famous `linters`_ which are well known in the software community are
 `flake8`_ and `jslint`_ (the former is used to lint the `sqlfluff` project
@@ -66,13 +66,24 @@ this is done in the wild in one of the following ways:
 
 All of these templating tools are great for `modularity`_ but they also
 mean that the SQL files themselves are no longer valid SQL code, because
-they now contain these configured *placeholder* values, inteded to
+they now contain these configured *placeholder* values, intended to
 improve modularity.
 
 Sqlfluff allows limited templating using both of the methods outlined
 above, to allow you to still lint those SQL files as part of your CI/CD
 pipeline (which is great 🙌), rather than waiting until you're in production
 (which is bad 🤦, and maybe too late).
+
+During the CI/CD pipeline (or any time that we need to handle `templated`_
+code), Sqlfluff needs additional info in order to interpret your templates
+as valid SQL code. You do so by providing dummy parameters in Sqlfluff
+configuration files. When substituted into the template, these values should
+evaluate to valid SQL (so Sqlfluff can check its style, formatting, and
+correctness), but the values don't need to match actual values used in
+production. This means that you can use *much simpler* dummy values than
+what you would really use. The recommendation is to use *the simplest*
+possible dummy value that still allows your code to evaluate to valid SQL
+so that the configuration values can be a streamlined as possible.
 
 .. _`infrastructure as code`: https://en.wikipedia.org/wiki/Infrastructure_as_code
 .. _`viewpoint section of the docs for the open-source tool dbt`: https://docs.getdbt.com/docs/viewpoint

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -3,6 +3,40 @@
 Rules Reference
 ===============
 
+`Rules` in `sqlfluff` are implemented as `crawlers`. These are entities
+which work their way through the parsed structure of a query to evaluate
+a particular rule or set of rules. The intent is that the definition of
+each specific rule should be really streamlined and only contain the logic
+for the rule itself, with all the other mechanics abstracted away.
+
+Specific Rules
+--------------
+
 .. automodule:: sqlfluff.rules.std
    :members:
    :member-order: alphabetical
+
+
+Implementation
+--------------
+
+.. autoclass:: sqlfluff.rules.base.RuleSet
+   :members:
+
+.. autoclass:: sqlfluff.rules.base.BaseCrawler
+   :members:
+   :private-members:
+
+.. autoclass:: sqlfluff.rules.base.LintResult
+   :members:
+
+.. autoclass:: sqlfluff.rules.base.LintFix
+   :members:
+
+
+The `_eval` function of each rule should take enough arguments that it can
+evaluate the position of the given segment in relation to it's neighbors,
+and that the segment which finally "triggers" the error, should be the one
+that would be corrected OR if the rule relates to something that is missing,
+then it should flag on the segment FOLLOWING, the place that the desired
+element is missing.

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -104,8 +104,8 @@ def lint(paths, **kwargs):
     """Lint SQL files via passing a list of files or using stdin.
 
     PATH is the path to a sql file or directory to lint. This can be either a
-    file (`path/to/file.sql`), a path (`directory/of/sql/files`), a single (`-`)
-    character to indicate reading from `stdin` or a dot/blank (`.`/` `) which will
+    file ('path/to/file.sql'), a path ('directory/of/sql/files'), a single ('-')
+    character to indicate reading from *stdin* or a dot/blank ('.'/' ') which will
     be interpreted like passing the current working directory as a path argument.
 
     Linting SQL files:
@@ -151,8 +151,8 @@ def fix(force, paths, **kwargs):
     """Fix SQL files.
 
     PATH is the path to a sql file or directory to lint. This can be either a
-    file (`path/to/file.sql`), a path (`directory/of/sql/files`), a single (`-`)
-    character to indicate reading from `stdin` or a dot/blank (`.`/` `) which will
+    file ('path/to/file.sql'), a path ('directory/of/sql/files'), a single ('-')
+    character to indicate reading from *stdin* or a dot/blank ('.'/' ') which will
     be interpreted like passing the current working directory as a path argument.
     """
     c = get_config(**kwargs)
@@ -213,8 +213,8 @@ def parse(path, **kwargs):
     """Parse SQL files and just spit out the result.
 
     PATH is the path to a sql file or directory to lint. This can be either a
-    file (`path/to/file.sql`), a path (`directory/of/sql/files`), a single (`-`)
-    character to indicate reading from `stdin` or a dot/blank (`.`/` `) which will
+    file ('path/to/file.sql'), a path ('directory/of/sql/files'), a single ('-')
+    character to indicate reading from *stdin* or a dot/blank ('.'/' ') which will
     be interpreted like passing the current working directory as a path argument.
     """
     c = get_config(**kwargs)


### PR DESCRIPTION
As raised in #13 by @barrywhart - the current docs are bit confusing about what role templating plays.

This hopefully addresses that a little by introducing a section on how sqlfluff fits into a modern data architecture and what role templating plays in that.

This PR also fleshes out the documentation around rules, adding autodoc for the base rule classes.