### PR TITLE
Safe merging of changed elements while templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Templating support (jinja2, python or raw).
   - Variables + Macros.
+  - The `fix` command is also sensitive to fixing over templates
+    and will skip certain fixes if it feels that it's conflicted.
 - Config file support, including specifying context for the templater.
 - Documentation via Sphinx and readthedocs.
   - Including a guide on the role of SQL in the real world.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ about the architecture of sqlfluff, you can find [more here](https://sqlfluff.re
   - [x] jinja2 compatible linting (for dbt)
     - [x] a preconfigured default set of templating macros for dbt use which can be loaded
           as config.
+  - [ ] Move the configuration of the *lexer* into the dialect.
 - [ ] Documentation
   - [x] Basic architectural principles
   - [ ] Update CLI docs to match current state

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -180,8 +180,6 @@ def fix(force, paths, **kwargs):
             result = lnt.lint_paths(paths, fix=True)
             click.echo('Persisting Changes...')
             result.persist_changes()
-            # TODO: Make return value of persist_changes() a more interesting result and then format it
-            # click.echo(format_linting_fixes(result, verbose=verbose), color=color)
             click.echo('Done. Please check your files to confirm.')
         else:
             click.echo('Are you sure you wish to attempt to fix these? [Y/n] ', nl=False)
@@ -191,9 +189,7 @@ def fix(force, paths, **kwargs):
                 click.echo('Attempting fixes...')
                 result = lnt.lint_paths(paths, fix=True)
                 click.echo('Persisting Changes...')
-                result.persist_changes()
-                # TODO: Make return value of persist_changes() a more interesting result and then format it
-                # click.echo(format_linting_fixes(fixes, verbose=verbose), color=color)
+                result.persist_changes(verbosity=verbose)
                 click.echo('Done. Please check your files to confirm.')
             elif c == 'n':
                 click.echo('Aborting...')

--- a/test/fixtures/templater/jinja_d_roundtrip/.sqlfluff
+++ b/test/fixtures/templater/jinja_d_roundtrip/.sqlfluff
@@ -1,0 +1,3 @@
+[sqlfluff:templater:jinja:context]
+some_field=nothing_interesting
+my_table=another_table

--- a/test/fixtures/templater/jinja_d_roundtrip/test.sql
+++ b/test/fixtures/templater/jinja_d_roundtrip/test.sql
@@ -1,0 +1,9 @@
+select
+    {{some_field}},
+    (1+2 )  AS kev,
+  "wrongly indented field" as something_else,
+    trailing_whitespace    ,    
+    4678.9
+FROM  {{my_table}}
+ WHERE indentation  = "wrong" and    NotSpacedProperly
+    

--- a/test/fixtures/templater/jinja_d_roundtrip/test.sql
+++ b/test/fixtures/templater/jinja_d_roundtrip/test.sql
@@ -1,9 +1,10 @@
 select
     {{some_field}},
-    (1+2 )  AS kev,
+    (1+2 ) AS kev,
   "wrongly indented field" as something_else,
     trailing_whitespace    ,    
     4678.9
-FROM  {{my_table}}
- WHERE indentation  = "wrong" and    NotSpacedProperly
+  from {{my_table}}
+ where indentation  = "wrong" AND    NotSpacedProperly
+ AND 4+6 > 9
     

--- a/test/rules_std_roundtrip_test.py
+++ b/test/rules_std_roundtrip_test.py
@@ -3,6 +3,8 @@
 import tempfile
 import os
 import shutil
+import re
+import pytest
 
 from click.testing import CliRunner
 
@@ -36,6 +38,55 @@ def generic_roundtrip_test(source_file, rulestring):
     shutil.rmtree(tempdir_path)
 
 
+def jinja_roundtrip_test(source_path, rulestring, sqlfile='test.sql', cfgfile='.sqlfluff'):
+    """Run a roundtrip test path and rule.
+
+    We take a file buffer, lint, fix and lint, finally checking that
+    the file fails initially but not after fixing. Additionally
+    we also check that we haven't messed up the templating tags
+    in the process.
+    """
+    tempdir_path = tempfile.mkdtemp()
+    sql_filepath = os.path.join(tempdir_path, sqlfile)
+    cfg_filepath = os.path.join(tempdir_path, cfgfile)
+
+    # Copy the SQL file
+    with open(sql_filepath, mode='w') as dest_file:
+        with open(os.path.join(source_path, sqlfile), mode='r') as source_file:
+            for line in source_file:
+                dest_file.write(line)
+    # Copy the Config file
+    with open(cfg_filepath, mode='w') as dest_file:
+        with open(os.path.join(source_path, cfgfile), mode='r') as source_file:
+            for line in source_file:
+                dest_file.write(line)
+
+    with open(sql_filepath, mode='r') as f:
+        # Get a record of the pre-existing jinja tags
+        tags = re.findall(r"{{[^}]*}}|{%[^}%]*%}", f.read(), flags=0)
+
+    runner = CliRunner()
+    # Check that we first detect the issue
+    result = runner.invoke(lint, ['--rules', rulestring, sql_filepath])
+    assert result.exit_code == 65
+    # Fix the file (in force mode)
+    result = runner.invoke(fix, ['--rules', rulestring, '-f', sql_filepath])
+    assert result.exit_code == 0
+    # Now lint the file and check for exceptions
+    result = runner.invoke(lint, ['--rules', rulestring, sql_filepath])
+    assert result.exit_code == 0
+
+    with open(sql_filepath, mode='r') as f:
+        # Check that the tags are all still there!
+        new_tags = re.findall(r"{{[^}]*}}|{%[^}%]*%}", f.read(), flags=0)
+
+    # Clear up the temp dir
+    shutil.rmtree(tempdir_path)
+
+    # Assert that the tags are the same
+    assert tags == new_tags
+
+
 def test__cli__command__fix_L001():
     """Test the round trip of detecting, fixing and then not detecting rule L001."""
     with open('test/fixtures/linter/indentation_errors.sql', mode='r') as f:
@@ -58,3 +109,9 @@ def test__cli__command__fix_L010():
     """Test the round trip of detecting, fixing and then not detecting rule L008."""
     with open('test/fixtures/linter/whitespace_errors.sql', mode='r') as f:
         generic_roundtrip_test(f, 'L010')
+
+
+@pytest.mark.parametrize("rule", ["L010", "L001"])
+def test__cli__command__fix_templated(rule):
+    """Roundtrip test, making sure that we don't drop tags while templating."""
+    jinja_roundtrip_test('test/fixtures/templater/jinja_d_roundtrip', rule)


### PR DESCRIPTION
This closes #50 

Test case and code to manage safe merging of changes into a fixed script without wiping the templating tags.