### PR TITLE
Process dirs and files in alphabetical order

### DIFF
--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -1,11 +1,9 @@
 """Sqlfluff is a SQL linter for humans."""
-
-import configparser
 import pkg_resources
-
+from six.moves import configparser
 
 # Get the current version
 config = configparser.ConfigParser()
-config.read_file(open(pkg_resources.resource_filename('sqlfluff', 'config.ini')))
+config.read([pkg_resources.resource_filename('sqlfluff', 'config.ini')])
 
 __version__ = config.get('sqlfluff', 'version')

--- a/src/sqlfluff/config.py
+++ b/src/sqlfluff/config.py
@@ -1,7 +1,9 @@
 """Module for loading config."""
 
-import configparser
 import os
+import sys
+
+from six.moves import configparser
 
 from .dialects import dialect_selector
 from .templaters import templater_selector
@@ -107,7 +109,10 @@ class ConfigLoader(object):
         """
         buff = []
         # Disable interpolation so we can load macros
-        config = configparser.ConfigParser(interpolation=None)
+        kw = {}
+        if sys.version_info >= (3, 0):
+            kw['interpolation'] = None
+        config = configparser.ConfigParser(**kw)
         config.read(fpath)
         for k in config.sections():
             if k == 'sqlfluff':

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -558,17 +558,17 @@ class Linter(object):
             raise IOError("Specified path does not exist")
         elif os.path.isdir(path):
             # Then expand the path!
-            buffer = set()
+            buffer = []
             for dirpath, _, filenames in os.walk(path):
                 for fname in filenames:
                     for ext in self.sql_exts:
                         # is it a sql file?
                         if fname.endswith(ext):
                             # join the paths and normalise
-                            buffer.add(os.path.normpath(os.path.join(dirpath, fname)))
-            return buffer
+                            buffer.append(os.path.normpath(os.path.join(dirpath, fname)))
+            return sorted(buffer)
         else:
-            return set([path])
+            return [path]
 
     def lint_string_wrapped(self, string, fname='<string input>', verbosity=0, fix=False):
         """Lint strings directly."""


### PR DESCRIPTION
- [X] Fix #75 (Output for subdirectories and files should be in alphabetical order)
- [X] Fix some Python 2.7 issues involving `ConfigParser`