### PR TITLE
Enable stdin input for fix cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist
 env
 .tox
 venv
+.venv 
 
 # Ignore coverage reports
 .coverage

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -172,6 +172,15 @@ def fix(force, paths, **kwargs):
         lnt.log(("The fix option is only available in combination"
                  " with --rules. This is for your own safety!"))
         sys.exit(1)
+
+    # handle stdin case. should output formatted sql to stdout and nothing else.
+    if ('-',) == paths:
+        stdin = sys.stdin.read()
+        result = lnt.lint_string_wrapped(stdin, fname='stdin', verbosity=verbose, fix=True)
+        stdout = result.paths[0].files[0].fix_string()
+        click.echo(stdout, nl=False)
+        sys.exit()
+
     # Lint the paths (not with the fix argument at this stage), outputting as we go.
     lnt.log("==== finding violations ====")
     try:

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -43,8 +43,8 @@ class LintedFile(namedtuple('ProtoFile', ['path', 'violations', 'time_dict', 'tr
         """Return True if there are no violations."""
         return len(self.violations) == 0
 
-    def persist_tree(self, verbosity=0):
-        """Persist changes to the given path.
+    def fix_string(self, verbosity=0):
+        """Obtain the changes to a path as a string.
 
         We use the file_mask to do a safe merge, avoiding any templated
         sections. First we need to detect where there have been changes
@@ -195,6 +195,22 @@ class LintedFile(namedtuple('ProtoFile', ['path', 'violations', 'time_dict', 'tr
                     ("Unexpected opcode {0} for template block! Please report this "
                      "issue on github with the query and rules you're trying to "
                      "fix.").format(templ_block[0]))
+
+        return write_buff
+
+    def persist_tree(self, verbosity=0):
+        """Persist changes to the given path.
+
+        We use the file_mask to do a safe merge, avoiding any templated
+        sections. First we need to detect where there have been changes
+        between the fixed and templated versions.
+
+        We use difflib.SequenceMatcher.get_opcodes
+        See: https://docs.python.org/3.7/library/difflib.html#difflib.SequenceMatcher.get_opcodes
+        It returns a list of tuples ('equal|replace', ia1, ia2, ib1, ib2).
+
+        """
+        write_buff = self.fix_string(verbosity=verbosity)
 
         # Actually write the file.
         with open(self.path, 'w') as f:

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -167,3 +167,12 @@ def test__cli__command__fix(rule, fname):
     """Test the round trip of detecting, fixing and then not detecting rule L001."""
     with open(fname, mode='r') as f:
         generic_roundtrip_test(f, rule)
+
+
+def test__cli__command_fix_stdin(monkeypatch):
+    """Check stdin input for fix works."""
+    sql = 'select * from tbl'
+    expected = 'fixed sql!'
+    monkeypatch.setattr("sqlfluff.linter.LintedFile.fix_string", lambda x: expected)
+    result = invoke_assert_code(args=[fix, ('-', '--rules', 'L001')], kwargs=dict(input=sql))
+    assert result.output == expected


### PR DESCRIPTION
A fix for #86 

The docs say this is possible but it is not! My guess is that @alanmcruickshank forgot that stdin was not set up for fix when it was set up for lint :-)

Anyway here it is!

The flow i was thinking about was 

```sh
echo "  SELECT a  +  b FROM tbl;  "  | sqlfluff fix - --rules L001  
```

So that this can be piped again, the usual echos had to be done away with, otherwise doing something like this would not be as expected:

```sh
echo "  SELECT a  +  b FROM tbl;  "  | sqlfluff fix - --rules L001 > fixed.sql
```

For this to work I had to move the internals of `LintedFile.persist_tree` to a new function which produces a fixed string first.