### PR TITLE
Fixes to recursive parsing and Set expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `--format` option to the `parse` command that allows a yaml output. This
+  is mostly to make test writing easier in the development process but
+  might also be useful for other things.
+- Parsing of set operations like `UNION`.
+
 ## [0.2.4] - 2019-12-06
 
 ### Added

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -80,6 +80,9 @@ def test__cli__command_lint_stdin(command):
     (parse, ['-n', 'test/fixtures/cli/passing_b.sql']),
     # Check basic parsing, with the code only option
     (parse, ['-n', 'test/fixtures/cli/passing_b.sql', '-c']),
+    # Check basic parsing, with the yaml output
+    (parse, ['-n', 'test/fixtures/cli/passing_b.sql', '-c', '-f', 'yaml']),
+    (parse, ['-n', 'test/fixtures/cli/passing_b.sql', '--format', 'yaml']),
     # Check linting works in specifying rules
     (lint, ['-n', '--rules', 'L001', 'test/fixtures/linter/operator_errors.sql']),
     # Check linting works in specifying multiple rules

--- a/test/fixtures/parser/ansi/select_e.sql
+++ b/test/fixtures/parser/ansi/select_e.sql
@@ -1,0 +1,22 @@
+-- Union expressions
+SELECT
+    col_a as foo
+FROM some_table
+
+UNION
+
+SELECT
+    col_b as foo
+FROM another_table
+
+UNION ALL
+
+SELECT
+    col_c as foo
+FROM this_other_table
+
+INTERSECT
+
+SELECT
+    col_d as foo
+FROM the_last_table

--- a/test/fixtures/parser/ansi/select_e.yml
+++ b/test/fixtures/parser/ansi/select_e.yml
@@ -1,0 +1,66 @@
+file:
+    statement:
+      set_expression:
+      - select_statement:
+          keyword: SELECT
+          select_target_group:
+            select_target_element:
+              object_reference:
+                naked_identifier: col_a
+              alias_expression:
+                keyword: as
+                naked_identifier: foo
+          from_clause:
+            keyword: FROM
+            table_expression:
+              object_reference:
+                naked_identifier: some_table
+      - set_operator:
+          keyword: UNION
+      - select_statement:
+          keyword: SELECT
+          select_target_group:
+            select_target_element:
+              object_reference:
+                naked_identifier: col_b
+              alias_expression:
+                keyword: as
+                naked_identifier: foo
+          from_clause:
+            keyword: FROM
+            table_expression:
+              object_reference:
+                naked_identifier: another_table
+      - set_operator:
+        - keyword: UNION
+        - keyword: ALL
+      - select_statement:
+          keyword: SELECT
+          select_target_group:
+            select_target_element:
+              object_reference:
+                naked_identifier: col_c
+              alias_expression:
+                keyword: as
+                naked_identifier: foo
+          from_clause:
+            keyword: FROM
+            table_expression:
+              object_reference:
+                naked_identifier: this_other_table
+      - set_operator:
+          keyword: INTERSECT
+      - select_statement:
+          keyword: SELECT
+          select_target_group:
+            select_target_element:
+              object_reference:
+                naked_identifier: col_d
+              alias_expression:
+                keyword: as
+                naked_identifier: foo
+          from_clause:
+            keyword: FROM
+            table_expression:
+              object_reference:
+                naked_identifier: the_last_table


### PR DESCRIPTION
Found a fixed a bug in recursive parsing where if a segment had no `parse_grammar` but one of it's children *did*, then it wouldn't be expanded because it would be seen as unexpandable and the `expand` function would never be called on it.

That was found as part implementing `UNION` expressions and so also fixes #61 .