### PR TITLE
Issue 8: Warn if DISTINCT used with parentheses

### DIFF
--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -633,3 +633,19 @@ class Rule_L014(Rule_L010):
     """
 
     _target_elem = 'naked_identifier'
+
+
+@std_rule_set.register
+class Rule_L015(BaseCrawler):
+    """DISTINCT used with parentheses."""
+
+    def _eval(self, segment, raw_stack, memory, **kwargs):
+        """Uneccessary trailing whitespace.
+
+        Look for DISTINCT keyword followed by parenthesis.
+        """
+        # We only trigger on start_bracket (open parenthesis)
+        if segment.name == 'start_bracket' and len(raw_stack) > 0 and raw_stack[-1].name == 'DISTINCT':
+            # If we find DISTINCT followed by open_bracket, then bad.
+            return LintResult(anchor=segment)
+        return LintResult()

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -642,7 +642,7 @@ class Rule_L015(BaseCrawler):
     def _eval(self, segment, raw_stack, **kwargs):
         """Uneccessary trailing whitespace.
 
-        Look for DISTINCT keyword followed by parenthesis.
+        Look for DISTINCT keyword immediately followed by open parenthesis.
         """
         # We only trigger on start_bracket (open parenthesis)
         if segment.name == 'start_bracket' and len(raw_stack) > 0 and raw_stack[-1].name == 'DISTINCT':

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -639,7 +639,7 @@ class Rule_L014(Rule_L010):
 class Rule_L015(BaseCrawler):
     """DISTINCT used with parentheses."""
 
-    def _eval(self, segment, raw_stack, memory, **kwargs):
+    def _eval(self, segment, raw_stack, **kwargs):
         """Uneccessary trailing whitespace.
 
         Look for DISTINCT keyword followed by parenthesis.

--- a/test/rules_std_test.py
+++ b/test/rules_std_test.py
@@ -63,7 +63,6 @@ def assert_rule_pass_in_sql(code, sql):
 # ############## STD RULES TESTS
 @pytest.mark.parametrize("rule,pass_fail,qry,fixed", [
     ("L001", 'fail', 'SELECT 1     \n', 'SELECT 1\n'),
-    ("L015", 'fail', 'SELECT DISTINCT(a)', None),
     ('L002', 'fail', '    \t    \t    SELECT 1', None),
     ('L003', 'fail', '     SELECT 1', '    SELECT 1'),
     ('L004', 'pass', '   \nSELECT 1', None),
@@ -74,6 +73,11 @@ def assert_rule_pass_in_sql(code, sql):
     ('L008', 'fail', 'SELECT 1,   4', 'SELECT 1, 4'),
     ('L014', 'pass', 'SELECT a, b', None),
     ('L014', 'pass', 'SELECT A, B', None),
+    ("L015", 'fail', 'SELECT DISTINCT(a)', None),
+    ("L015", 'fail', 'SELECT DISTINCT(a + b) * c', None),
+    # Space after DISTINCT makes it okay...
+    ("L015", 'pass', 'SELECT DISTINCT (a)', None), # A bit iffy...
+    ("L015", 'pass', 'SELECT DISTINCT (a + b) * c', None), # Definitely okay
     # Test that fixes are consistent
     ('L014', 'fail', 'SELECT a,   B', 'SELECT a,   b'),
     ('L014', 'fail', 'SELECT B,   a', 'SELECT B,   A'),

--- a/test/rules_std_test.py
+++ b/test/rules_std_test.py
@@ -63,6 +63,7 @@ def assert_rule_pass_in_sql(code, sql):
 # ############## STD RULES TESTS
 @pytest.mark.parametrize("rule,pass_fail,qry,fixed", [
     ("L001", 'fail', 'SELECT 1     \n', 'SELECT 1\n'),
+    ("L015", 'fail', 'SELECT DISTINCT(a)', None),
     ('L002', 'fail', '    \t    \t    SELECT 1', None),
     ('L003', 'fail', '     SELECT 1', '    SELECT 1'),
     ('L004', 'pass', '   \nSELECT 1', None),

--- a/test/rules_std_test.py
+++ b/test/rules_std_test.py
@@ -76,8 +76,8 @@ def assert_rule_pass_in_sql(code, sql):
     ("L015", 'fail', 'SELECT DISTINCT(a)', None),
     ("L015", 'fail', 'SELECT DISTINCT(a + b) * c', None),
     # Space after DISTINCT makes it okay...
-    ("L015", 'pass', 'SELECT DISTINCT (a)', None), # A bit iffy...
-    ("L015", 'pass', 'SELECT DISTINCT (a + b) * c', None), # Definitely okay
+    ("L015", 'pass', 'SELECT DISTINCT (a)', None),  # A bit iffy...
+    ("L015", 'pass', 'SELECT DISTINCT (a + b) * c', None),  # Definitely okay
     # Test that fixes are consistent
     ('L014', 'fail', 'SELECT a,   B', 'SELECT a,   b'),
     ('L014', 'fail', 'SELECT B,   a', 'SELECT B,   A'),


### PR DESCRIPTION
This is a proposed change to address #8. The implementation was a little different than we thought it might be. In this case, `DISTINCT` is still being parsed as a keyword, not a function. My implementation may be pretty naive -- feedback is definitely welcome!