### PR TITLE
#105: Usage documentation for the diff-quality integration

### DIFF
--- a/docs/source/diff-quality.rst
+++ b/docs/source/diff-quality.rst
@@ -2,8 +2,8 @@
 
 For projects with large amounts of (potentially imperfect) SQL code, the full
 SQLFluff output could be very large, which can be distracting -- perhaps the CI
-build for a one-line SQL change shouldn't encourage the developer to fix lots of
-unrelated quality issues.
+build for a one-line SQL change shouldn't encourage the developer to fix lots
+of unrelated quality issues.
 
 To support this use case, SQLFluff integrates with a quality checking tool
 called `diff-quality`. By running SQLFluff using `diff-quality` (rather than
@@ -33,6 +33,8 @@ Getting Started
 2. In your CI build script, run `diff-quality`, specifying SQLFluff as the
 underlying tool, e.g.
 
+.. code-block:: bash
+
     $ diff-quality --violations sqlfluff
     -------------
     Diff Quality
@@ -52,6 +54,7 @@ For more information on `diff-quality`, see the
 such as:
 
 * Generating HTML reports
-* Controlling which branch to compare against (i.e. to determine new/changed lines). The default is `origin/master`.
+* Controlling which branch to compare against (i.e. to determine new/changed
+  lines). The default is `origin/master`.
 * Configuring `diff-quality` to return an error code if the quality is too low
 * Troubleshooting

--- a/docs/source/diff-quality.rst
+++ b/docs/source/diff-quality.rst
@@ -1,0 +1,61 @@
+.. _diff-quality:
+
+For projects with large amounts of (potentially imperfect) SQL code, the full
+SQLFluff output could be very large, which can be distracting -- perhaps the CI
+build for a one-line SQL change shouldn't encourage the developer to fix lots of
+unrelated quality issues.
+
+To support this use case, SQLFluff integrates with a quality checking tool
+called `diff-quality`. By running SQLFluff using `diff-quality` (rather than
+running it directly), you can limit the the output to the new or modified SQL
+in the branch (aka pull request or PR) containing the proposed changes.
+
+Currently, ``diff-quality`` requires that you are using ``git`` for version
+control.
+
+Installation
+------------
+
+To install the latest release of the `diff-quality` tool:
+
+.. code:: bash
+
+    pip install diff_cover
+
+NOTE: In order to use the SQLFluff integration, you must install `diff_cover`
+version 2.5.0 or higher.
+
+Getting Started
+---------------
+
+1. Set the current working directory to a ``git`` repository.
+
+2. In your CI build script, run `diff-quality`, specifying SQLFluff as the
+underlying tool:
+
+Example output:
+
+```
+$ diff-quality --violations sqlfluff
+-------------
+Diff Quality
+Quality Report: sqlfluff
+Diff: origin/master...HEAD, staged and unstaged changes
+-------------
+sql/audience_size_queries/constraints/_postcondition_check_gdpr_compliance.sql (0.0%):
+sql/audience_size_queries/constraints/_postcondition_check_gdpr_compliance.sql:5: Inconsistent capitalisation of unquoted identifiers.
+-------------
+Total:   1 line
+Violations: 1 line
+% Quality: 0%
+-------------
+```
+
+For more information on `diff-quality`, see the
+[documentation](https://diff-cover.readthedocs.io/en/latest/). It covers topics
+such as:
+
+* Generating HTML reports
+* Controlling which branch to compare against (i.e. to determine new/changed lines). The default is `origin/master`.
+* Configuring `diff-quality` to return an error code if the quality is too low
+* Troubleshooting

--- a/docs/source/diff-quality.rst
+++ b/docs/source/diff-quality.rst
@@ -31,25 +31,21 @@ Getting Started
 1. Set the current working directory to a ``git`` repository.
 
 2. In your CI build script, run `diff-quality`, specifying SQLFluff as the
-underlying tool:
+underlying tool, e.g.
 
-Example output:
-
-```
-$ diff-quality --violations sqlfluff
--------------
-Diff Quality
-Quality Report: sqlfluff
-Diff: origin/master...HEAD, staged and unstaged changes
--------------
-sql/audience_size_queries/constraints/_postcondition_check_gdpr_compliance.sql (0.0%):
-sql/audience_size_queries/constraints/_postcondition_check_gdpr_compliance.sql:5: Inconsistent capitalisation of unquoted identifiers.
--------------
-Total:   1 line
-Violations: 1 line
-% Quality: 0%
--------------
-```
+    $ diff-quality --violations sqlfluff
+    -------------
+    Diff Quality
+    Quality Report: sqlfluff
+    Diff: origin/master...HEAD, staged and unstaged changes
+    -------------
+    sql/audience_size_queries/constraints/_postcondition_check_gdpr_compliance.sql (0.0%):
+    sql/audience_size_queries/constraints/_postcondition_check_gdpr_compliance.sql:5: Inconsistent capitalisation of unquoted identifiers.
+    -------------
+    Total:   1 line
+    Violations: 1 line
+    % Quality: 0%
+    -------------
 
 For more information on `diff-quality`, see the
 [documentation](https://diff-cover.readthedocs.io/en/latest/). It covers topics

--- a/docs/source/diff-quality.rst
+++ b/docs/source/diff-quality.rst
@@ -13,29 +13,27 @@ in the branch (aka pull request or PR) containing the proposed changes.
 Currently, ``diff-quality`` requires that you are using ``git`` for version
 control.
 
-Installation
-------------
+NOTE: Installing SQLFluff automatically installs the `diff_cover` package that
+provides the `diff-quality` tool.
 
-To install the latest release of the `diff-quality` tool:
+Adding `diff-quality` to your builds
+------------------------------------
 
-.. code:: bash
+In your CI build script:
 
-    pip install diff_cover
+1. Set the current working directory to the ``git`` repository containing the
+SQL code to be checked.
 
-NOTE: In order to use the SQLFluff integration, you must install `diff_cover`
-version 2.5.0 or higher.
-
-Getting Started
----------------
-
-1. Set the current working directory to a ``git`` repository.
-
-2. In your CI build script, run `diff-quality`, specifying SQLFluff as the
-underlying tool, e.g.
+2. Run `diff-quality`, specifying SQLFluff as the underlying tool:
 
 .. code-block:: bash
 
-    $ diff-quality --violations sqlfluff
+    diff-quality --violations sqlfluff
+
+The output will look something like:
+
+.. code-block:: bash
+
     -------------
     Diff Quality
     Quality Report: sqlfluff
@@ -48,6 +46,11 @@ underlying tool, e.g.
     Violations: 1 line
     % Quality: 0%
     -------------
+
+These messages are basically the same as those provided directly by SQLFluff,
+although the format is a little different. Note that `diff-quality` only lists
+the line _numbers_, not the character position. If you need the character
+position, you will need to run SQLFluff directly.
 
 For more information on `diff-quality`, see the
 [documentation](https://diff-cover.readthedocs.io/en/latest/). It covers topics

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,6 +42,7 @@ Contents
    configuration
    architecture
    cli
+   diff-quality
 
 
 Indices and tables


### PR DESCRIPTION
Addresses #105.

I don't have a good way to view `.rst` files at this time, so I suggest checking the markup as well as the content before merging.