### PR TITLE
Upgrade sphinx requirement - deprecating py2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # Requirements for building docs
-sphinx<2.2,>=1.5
+sphinx==2.3.1
 sphinx-click
 doc8


### PR DESCRIPTION
Now that we don't need to support py27 we can remove the deprecated outdated sphinx requirement.