### PR TITLE
Add badge for DeepCover

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Requirements Status](https://img.shields.io/requires/github/alanmcruickshank/sqlfluff.svg?style=flat-square)](https://requires.io/github/alanmcruickshank/sqlfluff/requirements/?branch=master)
 [![CircleCI](https://img.shields.io/circleci/build/gh/alanmcruickshank/sqlfluff/master?style=flat-square&logo=CircleCI)](https://circleci.com/gh/alanmcruickshank/sqlfluff/tree/master)
 [![ReadTheDocs](https://img.shields.io/readthedocs/sqlfluff?style=flat-square&logo=Read%20the%20Docs)](https://sqlfluff.readthedocs.io)
+[![DeepSource](https://img.shields.io/static/v1?label=DeepSource&message=on&color=green&style=flat-square)](https://deepsource.io/gh/alanmcruickshank/sqlfluff/)
 
 Bored of not having a good SQL linter that works with whichever dialiect you're
 working with? Fluff is an extensible and modular linter designed to help you write


### PR DESCRIPTION
@sanketsaurav I'm adding a badge for DeepSource.

If you're able to set yourselves up on https://shields.io/ that would be awesome. I saw that there's a build in badge in the UI - but not in the usual format. It also doesn't have a status returned for it. If you're able to make one then I'm happy to put it on the project.