### PR TITLE
Better support for table expressions and nested select

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -147,6 +147,7 @@ ansi_dialect.add(
     ValuesKeywordSegment=KeywordSegment.make('values'),
     SelectKeywordSegment=KeywordSegment.make('select'),
     WithKeywordSegment=KeywordSegment.make('with'),
+    OffsetKeywordSegment=KeywordSegment.make('offset'),
     InsertKeywordSegment=KeywordSegment.make('insert'),
     IntoKeywordSegment=KeywordSegment.make('into'),
     CommitKeywordSegment=KeywordSegment.make('commit'),
@@ -361,10 +362,26 @@ class TableExpressionSegment(BaseSegment):
     type = 'table_expression'
     match_grammar = Sequence(
         OneOf(
+            # Functions allowed here for table expressions.
+            # Perhaps this should just be in a dialect, but
+            # it seems sensible here for now.
+            Ref('FunctionSegment'),
             Ref('ObjectReferenceSegment'),
+            # Nested Selects
+            Bracketed(
+                Ref('SelectStatementSegment'),
+                Ref('WithCompoundStatementSegment')
+            )
             # Values clause?
         ),
-        Ref('AliasExpressionSegment', optional=True)
+        Ref('AliasExpressionSegment', optional=True),
+        Sequence(
+            Ref('WithKeywordSegment'),
+            Ref('OffsetKeywordSegment'),
+            Ref('AsKeywordSegment'),
+            Ref('SingleIdentifierGrammar'),
+            optional=True
+        ),
     )
 
 

--- a/test/fixtures/parser/ansi/select_i.sql
+++ b/test/fixtures/parser/ansi/select_i.sql
@@ -1,0 +1,10 @@
+-- This has a table expression and also an offset value.
+-- It also includes a nested SELECT
+SELECT SUM(CASE WHEN value != previous_value THEN 1.0 ELSE 0.0 END)
+      FROM (
+        SELECT
+          value,
+          CASE WHEN ix != 0 THEN LAG(value) OVER (ORDER BY ix ASC) ELSE value END AS previous_value
+        FROM UNNEST(sequence_validation_and_business_rules.sequence_validation_and_business_rules) AS value
+        WITH OFFSET AS ix
+      )

--- a/test/fixtures/parser/ansi/table_expression.sql
+++ b/test/fixtures/parser/ansi/table_expression.sql
@@ -1,0 +1,4 @@
+SELECT
+    y AS woy
+FROM
+    UNNEST(GENERATE_ARRAY(1, 53)) AS y


### PR DESCRIPTION
Rather than adding this to the bigquery dialect, it seemed common enough to add it to the main one for now. This closes #97 .