### PR TITLE
Fixes to indentation work

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![PyPi License](https://img.shields.io/pypi/l/sqlfluff.svg?style=flat-square)](https://pypi.org/project/sqlfluff/)
 [![PyPi Python Verions](https://img.shields.io/pypi/pyversions/sqlfluff.svg?style=flat-square)](https://pypi.org/project/sqlfluff/)
 [![PyPi Status](https://img.shields.io/pypi/status/sqlfluff.svg?style=flat-square)](https://pypi.org/project/sqlfluff/)
+[![PyPi Downloads](https://img.shields.io/pypi/dm/sqlfluff?style=flat-square)](https://pypi.org/project/sqlfluff/)
 
 [![codecov](https://img.shields.io/codecov/c/gh/alanmcruickshank/sqlfluff.svg?style=flat-square&logo=Codecov)](https://codecov.io/gh/alanmcruickshank/sqlfluff)
 [![Requirements Status](https://img.shields.io/requires/github/alanmcruickshank/sqlfluff.svg?style=flat-square)](https://requires.io/github/alanmcruickshank/sqlfluff/requirements/?branch=master)

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -222,7 +222,8 @@ class ObjectReferenceSegment(BaseSegment):
             Ref('_NonCodeSegment'), Ref('CommaSegment'),
             Ref('CastOperatorKeywordSegment')
         ),
-        code_only=False)
+        code_only=False
+    )
 
 
 @ansi_dialect.segment()
@@ -479,53 +480,48 @@ class SelectClauseSegment(BaseSegment):
 class JoinClauseSegment(BaseSegment):
     """Any number of join clauses, including the `JOIN` keyword."""
     type = 'join_clause'
-    match_grammar = OneOf(
-        # Types of join clause
-
-        # Old School Comma style clause
-        Sequence(
-            Ref('CommaSegment'),
-            Ref('TableExpressionSegment')
+    match_grammar = Sequence(
+        # NB These qualifiers are optional
+        AnyNumberOf(
+            Ref('FullKeywordSegment'),
+            Ref('InnerKeywordSegment'),
+            Ref('LeftKeywordSegment'),
+            Ref('CrossKeywordSegment'),
+            max_times=1,
+            optional=True
         ),
-
-        # New style Join clauses
-        Sequence(
-            # NB These qualifiers are optional
-            AnyNumberOf(
-                Ref('FullKeywordSegment'),
-                Ref('InnerKeywordSegment'),
-                Ref('LeftKeywordSegment'),
-                Ref('CrossKeywordSegment'),
-                max_times=1,
-                optional=True
+        Ref('JoinKeywordSegment'),
+        Indent,
+        Ref('TableExpressionSegment'),
+        # NB: this is optional
+        AnyNumberOf(
+            # ON clause
+            Sequence(
+                Ref('OnKeywordSegment'),
+                Indent,
+                OneOf(
+                    Ref('ExpressionSegment'),
+                    Bracketed(Ref('ExpressionSegment'))
+                ),
+                Dedent
             ),
-            Ref('JoinKeywordSegment'),
-            Ref('TableExpressionSegment'),
-            # NB: this is optional
-            AnyNumberOf(
-                # ON clause
-                Sequence(
-                    Ref('OnKeywordSegment'),
-                    OneOf(
-                        Ref('ExpressionSegment'),
-                        Bracketed(Ref('ExpressionSegment'))
+            # USING clause
+            Sequence(
+                Ref('UsingKeywordSegment'),
+                Indent,
+                Bracketed(
+                    Delimited(
+                        Ref('SingleIdentifierGrammar'),
+                        delimiter=Ref('CommaSegment')
                     )
                 ),
-                # USING clause
-                Sequence(
-                    Ref('UsingKeywordSegment'),
-                    Bracketed(
-                        Delimited(
-                            Ref('SingleIdentifierGrammar'),
-                            delimiter=Ref('CommaSegment')
-                        )
-                    )
-                ),
-                # Unqualified joins *are* allowed. They just might not
-                # be a good idea.
-                max_times=0
-            )
-        )
+                Dedent
+            ),
+            # Unqualified joins *are* allowed. They just might not
+            # be a good idea.
+            min_times=0
+        ),
+        Dedent
     )
 
 
@@ -545,11 +541,24 @@ class FromClauseSegment(BaseSegment):
     )
     parse_grammar = Sequence(
         Ref('FromKeywordSegment'),
-        Ref('TableExpressionSegment'),
+        Indent,
+        Delimited(
+            # Optional old school delimited joins
+            Ref('TableExpressionSegment'),
+            delimiter=Ref('CommaSegment'),
+            terminator=OneOf(
+                Ref('JoinKeywordSegment'),
+                Ref('CrossKeywordSegment'),
+                Ref('InnerKeywordSegment'),
+                Ref('LeftKeywordSegment'),
+                Ref('FullKeywordSegment')
+            )
+        ),
+        Dedent,
         AnyNumberOf(
             Ref('JoinClauseSegment'),
             optional=True
-        )
+        ),
     )
 
 
@@ -564,19 +573,25 @@ class CaseExpressionSegment(BaseSegment):
     )
     parse_grammar = Sequence(
         Ref('CaseKeywordSegment'),
+        Indent,
         AnyNumberOf(
             Sequence(
                 Ref('WhenKeywordSegment'),
+                Indent,
                 Ref('ExpressionSegment_TermThen'),
                 Ref('ThenKeywordSegment'),
-                Ref('ExpressionSegment_TermWhenElse')
+                Ref('ExpressionSegment_TermWhenElse'),
+                Dedent
             )
         ),
         Sequence(
             Ref('ElseKeywordSegment'),
+            Indent,
             Ref('ExpressionSegment_TermEnd'),
+            Dedent,
             optional=True
         ),
+        Dedent,
         Ref('EndKeywordSegment')
     )
 
@@ -746,7 +761,9 @@ class WhereClauseSegment(BaseSegment):
     )
     parse_grammar = Sequence(
         Ref('WhereKeywordSegment'),
-        Ref('ExpressionSegment')
+        Indent,
+        Ref('ExpressionSegment'),
+        Dedent
     )
 
 
@@ -807,6 +824,7 @@ class GroupByClauseSegment(BaseSegment):
     parse_grammar = Sequence(
         Ref('GroupKeywordSegment'),
         Ref('ByKeywordSegment'),
+        Indent,
         Delimited(
             OneOf(
                 Ref('ObjectReferenceSegment'),
@@ -819,7 +837,8 @@ class GroupByClauseSegment(BaseSegment):
                 Ref('LimitKeywordSegment'),
                 Ref('HavingKeywordSegment')
             )
-        )
+        ),
+        Dedent
     )
 
 
@@ -880,6 +899,7 @@ class WithCompoundStatementSegment(BaseSegment):
     match_grammar = StartsWith(Ref('WithKeywordSegment'))
     parse_grammar = Sequence(
         Ref('WithKeywordSegment'),
+        Indent,
         Delimited(
             Sequence(
                 Ref('ObjectReferenceSegment'),
@@ -889,6 +909,7 @@ class WithCompoundStatementSegment(BaseSegment):
             delimiter=Ref('CommaSegment'),
             terminator=Ref('SelectKeywordSegment')
         ),
+        Dedent,
         Ref('SelectStatementSegment')
     )
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -555,12 +555,17 @@ class FromClauseSegment(BaseSegment):
             )
         ),
         # NB: The JOIN clause is *part of* the FROM clause
-        # and so should be on a sub-indent of it.
+        # and so should be on a sub-indent of it. That isn't
+        # common practice however, so for now it will be assumed
+        # to be on the same level as the FROM clause. To change
+        # this behaviour, the Dedent would come after the AnyNumberOf
+        # rather than before. TODO: In future this might be
+        # configurable.
+        Dedent,
         AnyNumberOf(
             Ref('JoinClauseSegment'),
             optional=True
         ),
-        Dedent,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -554,11 +554,13 @@ class FromClauseSegment(BaseSegment):
                 Ref('FullKeywordSegment')
             )
         ),
-        Dedent,
+        # NB: The JOIN clause is *part of* the FROM clause
+        # and so should be on a sub-indent of it.
         AnyNumberOf(
             Ref('JoinClauseSegment'),
             optional=True
         ),
+        Dedent,
     )
 
 

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -537,9 +537,6 @@ class Linter:
 
             # Now extract all the unparsable segments
             for unparsable in parsed.iter_unparsables():
-                # # print("FOUND AN UNPARSABLE!")
-                # # print(unparsable)
-                # # print(unparsable.stringify())
                 # No exception has been raised explicitly, but we still create one here
                 # so that we can use the common interface
                 vs.append(

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -229,11 +229,14 @@ class BaseSegment:
                 if end_pos and elem.get_start_pos_marker() != end_pos:
                     raise TypeError(
                         "In {0} {1}, found an element of the segments tuple which"
-                        " isn't contigious with previous: {2} > {3}".format(
+                        " isn't contigious with previous: {2} > {3}. End pos: {4}."
+                        " Prev String: {5!r}".format(
                             text,
                             type(self),
                             prev_seg,
-                            elem
+                            elem,
+                            end_pos,
+                            prev_seg.raw
                         ))
                 start_pos = elem.get_start_pos_marker()
                 end_pos = elem.get_end_pos_marker()

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -337,24 +337,17 @@ class Rule_L003(BaseCrawler):
                 if this_line['indent_size'] != res[k]['indent_size']:
                     # Indents don't match even though balance is the same...
                     memory['problem_lines'].append(this_line_no)
-                    print(this_line_no, k, this_line['indent_balance'], res[k]['indent_balance'])
-                    for r in res:
-                        print(r, res[r]['indent_balance'], res[r]['indent_size'])
 
                     # Work out desired indent
                     if res[k]['indent_size'] == 0:
-                        print("A")
                         desired_indent = ''
                     elif this_line['indent_size'] == 0:
-                        print("B")
                         desired_indent = self._make_indent()
                     else:
-                        print("C")
                         # The previous indent.
                         desired_indent = ''.join(elem.raw for elem in res[k]['indent_buffer'])
 
                     # Make fixes
-                    print(repr(desired_indent))
                     fixes = self._coerce_indent_to(
                         desired_indent=desired_indent,
                         current_indent_buffer=this_line['indent_buffer'],

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -162,18 +162,7 @@ class Rule_L003(BaseCrawler):
 
         for elem in raw_stack:
             line_buffer.append(elem)
-            if in_indent:
-                if elem.type == 'whitespace':
-                    indent_buffer.append(elem)
-                elif elem.is_meta and elem.indent_val != 0:
-                    indent_balance += elem.indent_val
-                    if elem.indent_val > 0:
-                        clean_indent = True
-                else:
-                    in_indent = False
-                    this_indent_balance = indent_balance
-                    indent_size = self._indent_size(indent_buffer)
-            elif elem.type == 'newline':
+            if elem.type == 'newline':
                 result_buffer[line_no] = {
                     'line_no': line_no,
                     # Using slicing to copy line_buffer here to by py2 compliant
@@ -191,6 +180,17 @@ class Rule_L003(BaseCrawler):
                 in_indent = True
                 line_indent_stack = []
                 clean_indent = False
+            elif in_indent:
+                if elem.type == 'whitespace':
+                    indent_buffer.append(elem)
+                elif elem.is_meta and elem.indent_val != 0:
+                    indent_balance += elem.indent_val
+                    if elem.indent_val > 0:
+                        clean_indent = True
+                else:
+                    in_indent = False
+                    this_indent_balance = indent_balance
+                    indent_size = self._indent_size(indent_buffer)
             elif elem.is_meta and elem.indent_val != 0:
                 indent_balance += elem.indent_val
                 if elem.indent_val > 0:
@@ -337,17 +337,24 @@ class Rule_L003(BaseCrawler):
                 if this_line['indent_size'] != res[k]['indent_size']:
                     # Indents don't match even though balance is the same...
                     memory['problem_lines'].append(this_line_no)
+                    print(this_line_no, k, this_line['indent_balance'], res[k]['indent_balance'])
+                    for r in res:
+                        print(r, res[r]['indent_balance'], res[r]['indent_size'])
 
                     # Work out desired indent
                     if res[k]['indent_size'] == 0:
+                        print("A")
                         desired_indent = ''
                     elif this_line['indent_size'] == 0:
+                        print("B")
                         desired_indent = self._make_indent()
                     else:
+                        print("C")
                         # The previous indent.
                         desired_indent = ''.join(elem.raw for elem in res[k]['indent_buffer'])
 
                     # Make fixes
+                    print(repr(desired_indent))
                     fixes = self._coerce_indent_to(
                         desired_indent=desired_indent,
                         current_indent_buffer=this_line['indent_buffer'],

--- a/test/fixtures/cli/passing_b.sql
+++ b/test/fixtures/cli/passing_b.sql
@@ -8,7 +8,7 @@ SELECT
     d.something,    -- Which a comment after it
     a.foo
 FROM tbl AS a
-    INNER JOIN b USING(common_id)
-    JOIN c ON (a.id = c.id)
-    LEFT JOIN d ON (a.id = d.other_id)
+INNER JOIN b USING(common_id)
+JOIN c ON (a.id = c.id)
+LEFT JOIN d ON (a.id = d.other_id)
 ORDER BY a.name ASC

--- a/test/fixtures/cli/passing_b.sql
+++ b/test/fixtures/cli/passing_b.sql
@@ -8,7 +8,7 @@ SELECT
     d.something,    -- Which a comment after it
     a.foo
 FROM tbl AS a
-INNER JOIN b USING(common_id)
-JOIN c ON (a.id = c.id)
-LEFT JOIN d ON (a.id = d.other_id)
+    INNER JOIN b USING(common_id)
+    JOIN c ON (a.id = c.id)
+    LEFT JOIN d ON (a.id = d.other_id)
 ORDER BY a.name ASC

--- a/test/fixtures/linter/autofix/ansi/004_L003_indentation_3/after.sql
+++ b/test/fixtures/linter/autofix/ansi/004_L003_indentation_3/after.sql
@@ -28,7 +28,7 @@ SELECT
     END AS size_bucket
 FROM
     audience_counts
-    JOIN
-        gdpr_safe_users
-        USING
-            (user_id)
+JOIN
+    gdpr_safe_users
+    USING
+        (user_id)

--- a/test/fixtures/linter/autofix/ansi/004_L003_indentation_3/after.sql
+++ b/test/fixtures/linter/autofix/ansi/004_L003_indentation_3/after.sql
@@ -1,0 +1,34 @@
+WITH
+    audience_counts AS (
+        SELECT
+            user_id,
+            list_id,
+            COUNT(email_id) AS audience
+        FROM
+            lists_emails AS list_emails
+        WHERE
+            list_emails.active != 'D'
+        GROUP BY
+            user_id,
+            list_id)
+
+SELECT
+    user_id,
+    list_id,
+    audience,
+    CASE
+        WHEN audience > 0 AND audience <= 200 THEN '< 200'
+        WHEN audience > 200
+            AND audience <= 2000 THEN '200 - 2,000'
+        WHEN audience > 2000 AND audience <= 10000 THEN '2,000 - 10,000'
+        WHEN audience > 10000
+            AND audience <= 50000 THEN '10,000 - 50,000'
+        WHEN audience > 50000 AND audience <= 500000 THEN '50,000 - 500,000'
+        WHEN audience > 500000 THEN '> 500,000'
+    END AS size_bucket
+FROM
+    audience_counts
+JOIN
+    gdpr_safe_users
+    USING
+        (user_id)

--- a/test/fixtures/linter/autofix/ansi/004_L003_indentation_3/after.sql
+++ b/test/fixtures/linter/autofix/ansi/004_L003_indentation_3/after.sql
@@ -28,7 +28,7 @@ SELECT
     END AS size_bucket
 FROM
     audience_counts
-JOIN
-    gdpr_safe_users
-    USING
-        (user_id)
+    JOIN
+        gdpr_safe_users
+        USING
+            (user_id)

--- a/test/fixtures/linter/autofix/ansi/004_L003_indentation_3/before.sql
+++ b/test/fixtures/linter/autofix/ansi/004_L003_indentation_3/before.sql
@@ -1,0 +1,34 @@
+WITH
+    audience_counts AS (
+        SELECT
+            user_id,
+            list_id,
+            COUNT(email_id) AS audience
+        FROM
+        lists_emails AS list_emails
+        WHERE
+            list_emails.active != 'D'
+        GROUP BY
+            user_id,
+            list_id)
+
+SELECT
+    user_id,
+    list_id,
+    audience,
+    CASE
+        WHEN audience > 0 AND audience <= 200 THEN '< 200'
+        WHEN audience > 200
+        AND audience <= 2000 THEN '200 - 2,000'
+        WHEN audience > 2000 AND audience <= 10000 THEN '2,000 - 10,000'
+        WHEN audience > 10000
+        AND audience <= 50000 THEN '10,000 - 50,000'
+        WHEN audience > 50000 AND audience <= 500000 THEN '50,000 - 500,000'
+        WHEN audience > 500000 THEN '> 500,000'
+    END AS size_bucket
+FROM
+    audience_counts
+JOIN
+    gdpr_safe_users
+USING
+    (user_id)

--- a/test/fixtures/templater/jinja_b/jinja.yml
+++ b/test/fixtures/templater/jinja_b/jinja.yml
@@ -38,4 +38,4 @@ file:
         table_expression:
           object_reference:
           - naked_identifier: some_table
-          newline: "\n"
+        newline: "\n"


### PR DESCRIPTION
fixes #151 .

@barrywhart @mrshu - can you review?

I've ironed out some bugs in the indentation code, but also been thinking about the *correct* indentation for the sample query, and I'd like to suggest a few changes. I think the correct indentation should look like this:

```
WITH
    audience_counts AS (
        SELECT
            user_id,
            list_id,
            COUNT(email_id) AS audience
        FROM
            lists_emails AS list_emails
        WHERE
            list_emails.active != 'D'
        GROUP BY
            user_id,
            list_id)

SELECT
    user_id,
    list_id,
    audience,
    CASE
        WHEN audience > 0 AND audience <= 200 THEN '< 200'
        WHEN audience > 200
            AND audience <= 2000 THEN '200 - 2,000'
        WHEN audience > 2000 AND audience <= 10000 THEN '2,000 - 10,000'
        WHEN audience > 10000
            AND audience <= 50000 THEN '10,000 - 50,000'
        WHEN audience > 50000 AND audience <= 500000 THEN '50,000 - 500,000'
        WHEN audience > 500000 THEN '> 500,000'
    END AS size_bucket
FROM
    audience_counts
    JOIN
        gdpr_safe_users
        USING
            (user_id)
```

With the notable changes being in the `FROM` clause. I think the `JOIN` is technically part of the `FROM` and so should be indented from it. Likewise the `USING` clause is part of the `JOIN` and so should likewise be indented.

Do you both agree with that suggestion? If it's a blanket *yes* then I'll just merge it. If you don't agree, then I think this might be a case for adding a configurable flag, where this is the default setting, but it can be over-ridden. In that case I'm assuming it's the indentation of `JOIN` which is going to be the most controversial (heck, I don't even indent it like this at the moment) - so that seems like the obvious place.

On the other hand, I'd like sqlfluff to encourage people to do things *correctly* if at all possible, so I think if we agree what is *correct*, then we should make that the default.

Thoughts?

