### PR TITLE
Reorganise old tests and add support for functions with gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic fix testing, to help support the newer more complicated rules.
 - Interval literals
 - Support for the `source` macro from dbt. Thanks [@Dandandan](https://github.com/Dandandan)
+- Support for functions with spaces between the function name and the brackets
+  and a linting rule `L017` to catch this.
 
 ## [0.2.4] - 2019-12-06
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -297,7 +297,6 @@ class FunctionSegment(BaseSegment):
             Bracketed(
                 Anything(optional=True)
             ),
-            code_only=False
         ),
         Sequence(
             Ref('OverKeywordSegment'),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -341,7 +341,6 @@ class FunctionSegment(BaseSegment):
                     optional=True
                 )
             ),
-            code_only=False
         ),
         # Optional suffix for window functions.
         # TODO: Should this be in a different dialect?
@@ -439,9 +438,9 @@ class SelectTargetElementSegment(BaseSegment):
         Sequence(Ref('SingleIdentifierGrammar'), Ref('DotSegment'), Ref('StarSegment'), code_only=False),
         Sequence(
             OneOf(
-                Ref('ObjectReferenceSegment'),
                 Ref('LiteralGrammar'),
-                Ref('FunctionSegment')
+                Ref('FunctionSegment'),
+                Ref('ObjectReferenceSegment')
             ),
             Ref('AliasExpressionSegment', optional=True)
         ),

--- a/src/sqlfluff/parser/grammar.py
+++ b/src/sqlfluff/parser/grammar.py
@@ -490,7 +490,7 @@ class OneOf(BaseGrammar):
                             break
                     m = MatchResult(matched_segments, unmatched_segments)
                 if best_match:
-                    if len(m) > len(best_match):
+                    if len(m.raw_matched()) > len(best_match.raw_matched()):
                         best_match = m
                     else:
                         continue
@@ -498,7 +498,7 @@ class OneOf(BaseGrammar):
                     best_match = m
                 parse_match_logging(
                     self.__class__.__name__,
-                    '_match', "Saving Match of Length {0}:  {1}".format(len(m), m),
+                    '_match', "Saving Match of Length {0}:  {1}".format(len(m.raw_matched()), m),
                     parse_context=parse_context, v_level=self.v_level)
 
         # No full match from the first time round. If we've got a
@@ -532,7 +532,7 @@ class OneOf(BaseGrammar):
                 # still got options.
                 if m:
                     if best_match:
-                        if len(best_match) > len(m):
+                        if len(best_match.raw_matched()) > len(m.raw_matched()):
                             best_match = m
                         else:
                             continue
@@ -540,7 +540,7 @@ class OneOf(BaseGrammar):
                         best_match = m
                     parse_match_logging(
                         self.__class__.__name__,
-                        '_match', "Last-Ditch: Saving Match of Length {0}:  {1}".format(len(m), m),
+                        '_match', "Last-Ditch: Saving Match of Length {0}:  {1}".format(len(m.raw_matched()), m),
                         parse_context=parse_context, v_level=self.v_level)
             # if we've got something good, return it
             if best_match:

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -42,6 +42,22 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
         ("ExpressionSegment",
          ("CASE WHEN id = 1 THEN CASE WHEN true THEN 'something' "
           "ELSE 'nothing' END ELSE 'test' END")),
+        # Casting expressions
+        # https://github.com/alanmcruickshank/sqlfluff/issues/161
+        ("ExpressionSegment",
+         "CAST(ROUND(online_sales / 1000.0) AS varchar)"),
+        # Like expressions
+        # https://github.com/alanmcruickshank/sqlfluff/issues/170
+        ("ExpressionSegment",
+         "name NOT LIKE '%y'"),
+        # Functions with a space
+        # https://github.com/alanmcruickshank/sqlfluff/issues/171
+        ("SelectTargetElementSegment",
+         "MIN (test.id) AS min_test_id"),
+        # Interval literals
+        # https://github.com/alanmcruickshank/sqlfluff/issues/148
+        ("ExpressionSegment",
+         "DATE_ADD(CURRENT_DATE('America/New_York'), INTERVAL 1 year)")
     ]
 )
 def test__dialect__ansi_specific_segment_parses(segmentref, raw, caplog):

--- a/test/fixtures/linter/autofix/ansi/005_L017_function_spacing/after.sql
+++ b/test/fixtures/linter/autofix/ansi/005_L017_function_spacing/after.sql
@@ -1,0 +1,4 @@
+SELECT
+    min(col_a) as foo,
+    max(col_b) as bar
+FROM tbl

--- a/test/fixtures/linter/autofix/ansi/005_L017_function_spacing/before.sql
+++ b/test/fixtures/linter/autofix/ansi/005_L017_function_spacing/before.sql
@@ -1,0 +1,5 @@
+SELECT
+    min (col_a) as foo,
+    max /* a really obnoxious comment */
+(col_b) as bar
+FROM tbl

--- a/test/fixtures/parser/ansi/select_k.sql
+++ b/test/fixtures/parser/ansi/select_k.sql
@@ -1,4 +1,0 @@
--- Interval literals
--- https://github.com/alanmcruickshank/sqlfluff/issues/148
-SELECT
-    DATE_ADD(CURRENT_DATE('America/New_York'), INTERVAL 1 year)

--- a/test/fixtures/parser/ansi/select_s.sql
+++ b/test/fixtures/parser/ansi/select_s.sql
@@ -1,5 +1,0 @@
--- Like and Not Like
--- https://github.com/alanmcruickshank/sqlfluff/issues/170
-SELECT *
-FROM test
-WHERE name NOT LIKE '%y';

--- a/test/fixtures/parser/ansi/select_t.sql
+++ b/test/fixtures/parser/ansi/select_t.sql
@@ -1,5 +1,0 @@
--- Casting expressions
--- https://github.com/alanmcruickshank/sqlfluff/issues/161
-SELECT
-    CAST(ROUND(online_sales / 1000.0) AS varchar) AS result
-FROM sales


### PR DESCRIPTION
Fixes #171 .

Also introduces rule L017 to catch functions with unwanted spaces.