### PR TITLE
Array notation and match caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for functions with spaces between the function name and the brackets
   and a linting rule `L017` to catch this.
 - Efficiency cache for faster pruning of the parse tree.
+- Parsing of array notation as using in BigQuery and Postgres.
 
 ## [0.2.4] - 2019-12-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for the `source` macro from dbt. Thanks [@Dandandan](https://github.com/Dandandan)
 - Support for functions with spaces between the function name and the brackets
   and a linting rule `L017` to catch this.
+- Efficiency cache for faster pruning of the parse tree.
 
 ## [0.2.4] - 2019-12-06
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -252,14 +252,16 @@ class ArrayAccessorSegment(BaseSegment):
         square=True
     )
     parse_grammar = Bracketed(
-        Sequence(
-            Ref('ExpressionSegment'),
-            # Optional slice expression
-            Sequence(
-                Ref('ColonSegment'),
-                Ref('ExpressionSegment'),
-                optional=True
+        Delimited(
+            # We use the no-match version here so we get the correct
+            # handling of the potential colon. We also use Delimited
+            # so that we look for the colon FIRST, because we should
+            # know to expect one and the parser gets confused otherwise.
+            OneOf(
+                Ref('NumericLiteralSegment'),
+                Ref('ExpressionSegment_NoMatch')
             ),
+            delimiter=Ref('SliceSegment')
         ),
         # Use square brackets
         square=True

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -236,7 +236,8 @@ class ObjectReferenceSegment(BaseSegment):
         terminator=OneOf(
             Ref('_NonCodeSegment'), Ref('CommaSegment'),
             Ref('CastOperatorKeywordSegment'), Ref('StartSquareBracketSegment'),
-            Ref('StartBracketSegment')
+            Ref('StartBracketSegment'), Ref('ArithmeticBinaryOperatorGrammar'),
+            Ref('ComparisonOperatorGrammar')
         ),
         code_only=False
     )

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -235,9 +235,9 @@ class ObjectReferenceSegment(BaseSegment):
         delimiter=Ref('DotSegment'),
         terminator=OneOf(
             Ref('_NonCodeSegment'), Ref('CommaSegment'),
-            Ref('CastOperatorKeywordSegment')
+            Ref('CastOperatorKeywordSegment'), Ref('StartSquareBracketSegment'),
+            Ref('StartBracketSegment')
         ),
-        min_delimiters=0,
         code_only=False
     )
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -246,8 +246,12 @@ class ObjectReferenceSegment(BaseSegment):
 class ArrayAccessorSegment(BaseSegment):
     """An array accessor e.g. [3:4]."""
     type = 'array_accessor'
-    # match grammar (don't allow whitespace)
     match_grammar = Bracketed(
+        Anything(),
+        # Use square brackets
+        square=True
+    )
+    parse_grammar = Bracketed(
         Sequence(
             Ref('ExpressionSegment'),
             # Optional slice expression

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -49,6 +49,9 @@ ansi_dialect.set_lexer_struct([
     ("star", "singleton", "*", dict(is_code=True)),
     ("bracket_open", "singleton", "(", dict(is_code=True)),
     ("bracket_close", "singleton", ")", dict(is_code=True)),
+    ("sq_bracket_open", "singleton", "[", dict(is_code=True)),
+    ("sq_bracket_close", "singleton", "]", dict(is_code=True)),
+    ("colon", "singleton", ":", dict(is_code=True)),
     ("semicolon", "singleton", ";", dict(is_code=True)),
     ("code", "regex", r"[0-9a-zA-Z_]*", dict(is_code=True))
 ])
@@ -59,8 +62,11 @@ ansi_dialect.add(
     _NonCodeSegment=LambdaSegment.make(lambda x: not x.is_code, is_code=False, name='non_code'),
     # Real segments
     SemicolonSegment=KeywordSegment.make(';', name="semicolon"),
+    SliceSegment=KeywordSegment.make(':', name="slice"),
     StartBracketSegment=KeywordSegment.make('(', name='start_bracket', type='start_bracket'),
     EndBracketSegment=KeywordSegment.make(')', name='end_bracket', type='end_bracket'),
+    StartSquareBracketSegment=KeywordSegment.make('[', name='start_square_bracket', type='start_square_bracket'),
+    EndSquareBracketSegment=KeywordSegment.make(']', name='end_square_bracket', type='end_square_bracket'),
     CommaSegment=KeywordSegment.make(',', name='comma', type='comma'),
     DotSegment=KeywordSegment.make('.', name='dot', type='dot'),
     StarSegment=KeywordSegment.make('*', name='star'),
@@ -233,6 +239,26 @@ class ObjectReferenceSegment(BaseSegment):
         ),
         min_delimiters=0,
         code_only=False
+    )
+
+
+@ansi_dialect.segment()
+class ArrayAccessorSegment(BaseSegment):
+    """An array accessor e.g. [3:4]."""
+    type = 'array_accessor'
+    # match grammar (don't allow whitespace)
+    match_grammar = Bracketed(
+        Sequence(
+            Ref('ExpressionSegment'),
+            # Optional slice expression
+            Sequence(
+                Ref('ColonSegment'),
+                Ref('ExpressionSegment'),
+                optional=True
+            ),
+        ),
+        # Use square brackets
+        square=True
     )
 
 
@@ -706,6 +732,9 @@ ansi_dialect.add(
             ),
             Ref('LiteralGrammar'),
             Ref('ObjectReferenceSegment')
+        ),
+        AnyNumberOf(
+            Ref('ArrayAccessorSegment')
         ),
         Ref('ShorthandCastSegment', optional=True),
         code_only=False

--- a/src/sqlfluff/parser/grammar.py
+++ b/src/sqlfluff/parser/grammar.py
@@ -413,29 +413,29 @@ class Ref(BaseGrammar):
         """
         elem = self._get_elem(dialect=parse_context.dialect)
 
-        if elem:
-            # First check against the efficiency Cache.
-            # Make a tuple of the incoming segments
-            seg_tuple = BaseSegment.segs_to_tuple(segments, show_raw=True)
-            self_name = self._get_ref()
-            if parse_context.blacklist.check(self_name, seg_tuple):
-                # This has been tried before.
-                parse_match_logging(
-                    self.__class__.__name__,
-                    'match', "SKIP",
-                    parse_context=parse_context, v_level=3, self_name=self_name)
-                return MatchResult.from_unmatched(segments)
-
-            # Match against that. NB We're not incrementing the match_depth here.
-            # References shouldn't relly count as a depth of match.
-            resp = elem._match(
-                segments=segments,
-                parse_context=parse_context.copy(match_segment=self._get_ref()))
-            if not resp:
-                parse_context.blacklist.mark(self_name, seg_tuple)
-            return resp
-        else:
+        if not elem:
             raise ValueError("Null Element returned! _elements: {0!r}".format(self._elements))
+
+        # First check against the efficiency Cache.
+        # Make a tuple of the incoming segments
+        seg_tuple = BaseSegment.segs_to_tuple(segments, show_raw=True)
+        self_name = self._get_ref()
+        if parse_context.blacklist.check(self_name, seg_tuple):
+            # This has been tried before.
+            parse_match_logging(
+                self.__class__.__name__,
+                'match', "SKIP",
+                parse_context=parse_context, v_level=3, self_name=self_name)
+            return MatchResult.from_unmatched(segments)
+
+        # Match against that. NB We're not incrementing the match_depth here.
+        # References shouldn't relly count as a depth of match.
+        resp = elem._match(
+            segments=segments,
+            parse_context=parse_context.copy(match_segment=self._get_ref()))
+        if not resp:
+            parse_context.blacklist.mark(self_name, seg_tuple)
+        return resp
 
     def expected_string(self, dialect=None, called_from=None):
         """Get the expected string from the referenced element."""

--- a/src/sqlfluff/parser/segments_common.py
+++ b/src/sqlfluff/parser/segments_common.py
@@ -13,7 +13,7 @@ we use, and will be common between all of them.
 import logging
 import re
 
-from .segments_base import (BaseSegment, RawSegment)
+from .segments_base import (BaseSegment, RawSegment, parse_match_logging)
 from .match import MatchResult
 
 
@@ -50,8 +50,10 @@ class KeywordSegment(RawSegment):
                 raw_comp = raw
             else:
                 raw_comp = raw.upper()
-            logging.debug("[PD:{0} MD:{1}] (KW) {2}.match considering {3!r} against {4!r}".format(
-                parse_context.parse_depth, parse_context.match_depth, cls.__name__, raw_comp, cls._template))
+
+            parse_match_logging(
+                cls.__name__[:10], 'match', 'KW',
+                parse_context=parse_context, v_level=4, pattern=cls._template, test=raw_comp, name=cls.__name__)
             if cls._template == raw_comp:
                 m = (cls(raw=raw, pos_marker=pos),)  # Return as a tuple
                 return MatchResult(m, segments[1:])
@@ -96,8 +98,9 @@ class ReSegment(KeywordSegment):
             sc = s
         if len(s) == 0:
             raise ValueError("Zero length string passed to ReSegment!?")
-        logging.debug("[PD:{0} MD:{1}] (RE) {2}.match considering {3!r} against {4!r}".format(
-            parse_context.parse_depth, parse_context.match_depth, cls.__name__, sc, cls._template))
+        parse_match_logging(
+            cls.__name__[:10], 'match', 'RE',
+            parse_context=parse_context, v_level=4, pattern=cls._template, test=sc, name=cls.__name__)
         # Try the regex
         result = re.match(cls._template, sc)
         if result:
@@ -142,8 +145,9 @@ class NamedSegment(KeywordSegment):
                 n = s.name.upper()
             else:
                 n = s.name
-            logging.debug("[PD:{0} MD:{1}] (KW) {2}.match considering {3!r} against {4!r}".format(
-                parse_context.parse_depth, parse_context.match_depth, cls.__name__, n, cls._template))
+            parse_match_logging(
+                cls.__name__[:10], 'match', 'NM',
+                parse_context=parse_context, v_level=4, pattern=cls._template, test=n, name=cls.__name__)
             if cls._template == n:
                 m = (cls(raw=s.raw, pos_marker=segments[0].pos_marker),)  # Return a tuple
                 return MatchResult(m, segments[1:])

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -61,6 +61,7 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
         # Array accessors
         ("ExpressionSegment", "my_array[1]"),
         ("ExpressionSegment", "my_array[OFFSET(1)]"),
+        ("ExpressionSegment", "my_array[5:8]"),
         ("ExpressionSegment", "4 + my_array[OFFSET(1)]"),
         ("ExpressionSegment", "bits[OFFSET(0)] + 7"),
         ("SelectTargetElementSegment",
@@ -70,12 +71,7 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
          "count_18_24 * bits[OFFSET(0)] + count_25_34"),
         ("SelectTargetElementSegment",
          ("(count_18_24 * bits[OFFSET(0)] + count_25_34)"
-          " / audience_size AS relative_abundance")),
-        ("SelectTargetElementSegment",
-         ("(count_18_24 * bits[OFFSET(0)] + count_25_34 * bits[OFFSET(1)] +"
-          "count_35_44 * bits[OFFSET(2)] + count_45_54 * bits[OFFSET(3)] +"
-          "count_55_64 * bits[OFFSET(4)] + count_65_plus * bits[OFFSET(5)])"
-          " / audience_size AS relative_abundance")),
+          " / audience_size AS relative_abundance"))
     ]
 )
 def test__dialect__ansi_specific_segment_parses(segmentref, raw, caplog):

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -57,7 +57,25 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
         # Interval literals
         # https://github.com/alanmcruickshank/sqlfluff/issues/148
         ("ExpressionSegment",
-         "DATE_ADD(CURRENT_DATE('America/New_York'), INTERVAL 1 year)")
+         "DATE_ADD(CURRENT_DATE('America/New_York'), INTERVAL 1 year)"),
+        # Array accessors
+        ("ExpressionSegment", "my_array[1]"),
+        ("ExpressionSegment", "my_array[OFFSET(1)]"),
+        ("ExpressionSegment", "4 + my_array[OFFSET(1)]"),
+        ("ExpressionSegment", "bits[OFFSET(0)] + 7"),
+        ("SelectTargetElementSegment",
+         ("(count_18_24 * bits[OFFSET(0)])"
+          " / audience_size AS relative_abundance")),
+        ("ExpressionSegment",
+         "count_18_24 * bits[OFFSET(0)] + count_25_34"),
+        ("SelectTargetElementSegment",
+         ("(count_18_24 * bits[OFFSET(0)] + count_25_34)"
+          " / audience_size AS relative_abundance")),
+        ("SelectTargetElementSegment",
+         ("(count_18_24 * bits[OFFSET(0)] + count_25_34 * bits[OFFSET(1)] +"
+          "count_35_44 * bits[OFFSET(2)] + count_45_54 * bits[OFFSET(3)] +"
+          "count_55_64 * bits[OFFSET(4)] + count_65_plus * bits[OFFSET(5)])"
+          " / audience_size AS relative_abundance")),
     ]
 )
 def test__dialect__ansi_specific_segment_parses(segmentref, raw, caplog):

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -71,7 +71,11 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
          "count_18_24 * bits[OFFSET(0)] + count_25_34"),
         ("SelectTargetElementSegment",
          ("(count_18_24 * bits[OFFSET(0)] + count_25_34)"
-          " / audience_size AS relative_abundance"))
+          " / audience_size AS relative_abundance")),
+        # Dense math expressions
+        # https://github.com/alanmcruickshank/sqlfluff/issues/178
+        # https://github.com/alanmcruickshank/sqlfluff/issues/179
+        ("SelectStatementSegment", "SELECT t.val/t.id FROM test WHERE id*1.0/id > 0.8"),
     ]
 )
 def test__dialect__ansi_specific_segment_parses(segmentref, raw, caplog):

--- a/test/fixtures/parser/ansi/select_s.sql
+++ b/test/fixtures/parser/ansi/select_s.sql
@@ -1,0 +1,10 @@
+-- Array notation (BigQuery and Postgres)
+-- https://github.com/alanmcruickshank/sqlfluff/issues/59
+SELECT
+  user_id,
+  list_id,
+  (count_18_24 * bits[OFFSET(0)] + count_25_34 * bits[OFFSET(1)] +
+   count_35_44 * bits[OFFSET(2)] + count_45_54 * bits[OFFSET(3)] +
+   count_55_64 * bits[OFFSET(4)] + count_65_plus * bits[OFFSET(5)]) / audience_size AS relative_abundance
+FROM
+    gcp_project.dataset.audience_counts_gender_age

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,13 @@ deps =
     -rrequirements.txt
     pytest
     pytest-cov
-# Include any other steps necessary for testing below
+# Include any other steps necessary for testing below.
+# {posargs} is there to allow us to specify specific tests, which
+# can then be invoked from tox by calling e.g.
+# tox -e py35 -- project/tests/test_file.py::TestClassName::test_method
 commands =
     python util.py clean-tests
-    pytest -vv --cov --cov-report=xml --junitxml=.test-reports/junit.xml
+    pytest -vv --cov --cov-report=xml --junitxml=.test-reports/junit.xml {posargs}
 setenv =
     COVERAGE_FILE = .coverage.{envname}
 


### PR DESCRIPTION
Implements Array notation as per #59. Also introduces some very lightweight pruning of match paths which have already been tried using the `ParseBlacklist` class.

@barrywhart This implements parsing for array notation - can you take a look at the example queries that it parses and see if they're what you had in mind?

Fixed #59 