### PR TITLE
"ignore" parameter and a few parsing tweeks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a linting rule `L017` to catch this.
 - Efficiency cache for faster pruning of the parse tree.
 - Parsing of array notation as using in BigQuery and Postgres.
+- Enable the `ignore` parameter on linting and fixing commands to ignore
+  particular kinds of violations.
 
 ## [0.2.4] - 2019-12-06
 

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -39,6 +39,11 @@ def common_options(f):
                            'Multiple rules can be specified with commas e.g. '
                            '`--exclude-rules L001,L002` will exclude violations of rule '
                            '`L001` and rule `L002`.'))(f)
+    f = click.option('--ignore', default=None,
+                     help=("Ignore particular families of errors so that they don't cause a failed "
+                           "run. For example `--ignore parsing` would mean that any parsing errors "
+                           "are ignored and don't influence the success or fail of a run. Multiple "
+                           "options are possible if comma seperated e.g. `--ignore parsing,templating`."))(f)
     return f
 
 

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -33,10 +33,14 @@ def format_violation(violation, verbose=0):
     else:
         raise ValueError("Unexpected violation format: {0}".format(violation))
 
+    if violation.ignore:
+        desc = 'IGNORE: ' + desc
+
     return (
         colorize(
             "L:{0:4d} | P:{1:4d} | {2} |".format(line, pos, code.rjust(4)),
-            'blue')
+            # Grey out the violation if we're ignoring it.
+            'lightgrey' if violation.ignore else 'blue')
         + " {0}".format(desc)
     )
 
@@ -59,8 +63,8 @@ def format_fix(fix, verbose=0):
 def format_file_violations(fname, res, verbose=0):
     """Format a set of violations in a `LintingResult`."""
     text_buffer = StringIO()
-    # Success is having no violations
-    success = len(res) == 0
+    # Success is having no violations (which aren't ignored)
+    success = sum(int(not violation.ignore) for violation in res) == 0
 
     # Only print the filename if it's either a failure or verbosity > 1
     if verbose > 1 or not success:

--- a/src/sqlfluff/config.py
+++ b/src/sqlfluff/config.py
@@ -266,6 +266,11 @@ class FluffConfig:
             {'core': overrides or {}})
         # Some configs require special treatment
         self._configs['core']['color'] = False if self._configs['core'].get('nocolor', False) else None
+        # Deal with potential ignore parameters
+        if self._configs['core'].get('ignore', None):
+            self._configs['core']['ignore'] = self._configs['core']['ignore'].split(',')
+        else:
+            self._configs['core']['ignore'] = []
         # Whitelists and blacklists
         if self._configs['core'].get('rules', None):
             self._configs['core']['rule_whitelist'] = self._configs['core']['rules'].split(',')

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -195,6 +195,8 @@ ansi_dialect.add(
     LikeKeywordSegment=KeywordSegment.make('like'),
     ILikeKeywordSegment=KeywordSegment.make('ilike'),
     RLikeKeywordSegment=KeywordSegment.make('rlike'),
+    RoleKeywordSegment=KeywordSegment.make('role'),
+    UserKeywordSegment=KeywordSegment.make('user'),
     # Some more grammars:
     IntervalKeywordSegment=KeywordSegment.make('interval'),
     LiteralGrammar=OneOf(
@@ -1360,7 +1362,12 @@ class AccessStatementSegment(BaseSegment):
                 )
             ),
             Ref('ToKeywordSegment'),
-            Ref('GroupKeywordSegment', optional=True),
+            OneOf(
+                Ref('GroupKeywordSegment'),
+                Ref('UserKeywordSegment'),
+                Ref('RoleKeywordSegment'),
+                optional=True
+            ),
             Ref('ObjectReferenceSegment'),
             Sequence(
                 Ref('WithKeywordSegment'),
@@ -1414,7 +1421,12 @@ class AccessStatementSegment(BaseSegment):
                 )
             ),
             Ref('FromKeywordSegment'),
-            Ref('GroupKeywordSegment', optional=True),
+            OneOf(
+                Ref('GroupKeywordSegment'),
+                Ref('UserKeywordSegment'),
+                Ref('RoleKeywordSegment'),
+                optional=True
+            ),
             Ref('ObjectReferenceSegment'),
             OneOf(
                 Ref('RestrictKeywordSegment'),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -90,7 +90,7 @@ ansi_dialect.add(
         _anti_template=r"^(SELECT|JOIN|ON|USING|CROSS|INNER|LEFT|RIGHT|OUTER|INTERVAL|CASE|FULL)$"),
     FunctionNameSegment=ReSegment.make(r"[A-Z][A-Z0-9_]*", name='function_name', type='function_name'),
     # Maybe data types should be more restrictive?
-    DatatypeSegment=ReSegment.make(r"[A-Z][A-Z0-9_]*", name='data_type', type='data_type'),
+    DatatypeIdentifierSegment=ReSegment.make(r"[A-Z][A-Z0-9_]*", name='data_type_identifier', type='data_type_identifier'),
     # Maybe date parts should be more restrictive
     DatepartSegment=ReSegment.make(r"[A-Z][A-Z0-9_]*", name='date_part', type='date_part'),
     QuotedIdentifierSegment=NamedSegment.make('double_quote', name='identifier', type='quoted_identifier'),
@@ -217,6 +217,27 @@ class IntervalLiteralSegment(BaseSegment):
         OneOf(
             Ref('QuotedLiteralSegment'),
             Ref('DatepartSegment')
+        )
+    )
+
+
+@ansi_dialect.segment()
+class DatatypeSegment(BaseSegment):
+    """A data type segment."""
+    type = 'data_type'
+    match_grammar = Sequence(
+        Ref('DatatypeIdentifierSegment'),
+        Bracketed(
+            OneOf(
+                Delimited(
+                    Ref('ExpressionSegment'),
+                    delimiter=Ref('CommaSegment')
+                ),
+                # The brackets might be empty for some cases...
+                optional=True
+            ),
+            # There may be no brackets for some data types
+            optional=True
         )
     )
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -131,6 +131,7 @@ ansi_dialect.add(
     ExceptKeywordSegment=KeywordSegment.make('except'),
     IntersectKeywordSegment=KeywordSegment.make('intersect'),
     OnKeywordSegment=KeywordSegment.make('on'),
+    OuterKeywordSegment=KeywordSegment.make('outer'),
     JoinKeywordSegment=KeywordSegment.make('join'),
     FullKeywordSegment=KeywordSegment.make('full'),
     InnerKeywordSegment=KeywordSegment.make('inner'),
@@ -531,6 +532,7 @@ class JoinClauseSegment(BaseSegment):
             max_times=1,
             optional=True
         ),
+        Ref('OuterKeywordSegment', optional=True),
         Ref('JoinKeywordSegment'),
         Indent,
         Ref('TableExpressionSegment'),

--- a/src/sqlfluff/errors.py
+++ b/src/sqlfluff/errors.py
@@ -4,6 +4,11 @@
 class SQLBaseError(ValueError):
     """Base Error Class for all violations."""
     _code = None
+    _identifier = 'base'
+
+    def __init__(self, *args, **kwargs):
+        self.ignore = kwargs.pop('ignore', False)
+        super(SQLBaseError, self).__init__(*args, **kwargs)
 
     def rule_code(self):
         """Fetch the code of the rule which cause this error.
@@ -91,6 +96,15 @@ class SQLBaseError(ValueError):
         """
         return self.rule_code(), self.line_no(), self.line_pos(), self.desc()
 
+    def ignore_if_in(self, ignore_iterable):
+        """Ignore this violation if it matches the iterable."""
+        # Type conversion
+        if isinstance(ignore_iterable, str):
+            ignore_iterable = []
+        # Ignoring
+        if self._identifier in ignore_iterable:
+            self.ignore = True
+
 
 class SQLTemplaterError(SQLBaseError):
     """An error which occured during templating.
@@ -101,6 +115,7 @@ class SQLTemplaterError(SQLBaseError):
 
     """
     _code = 'TMP'
+    _identifier = 'templating'
 
     def __init__(self, *args, **kwargs):
         self.pos = kwargs.pop('pos', None)
@@ -116,6 +131,7 @@ class SQLLexError(SQLBaseError):
 
     """
     _code = 'LXR'
+    _identifier = 'lexing'
 
     def __init__(self, *args, **kwargs):
         # Store the segment on creation - we might need it later
@@ -134,6 +150,7 @@ class SQLParseError(SQLBaseError):
 
     """
     _code = 'PRS'
+    _identifier = 'parsing'
 
     def __init__(self, *args, **kwargs):
         # Store the segment on creation - we might need it later
@@ -154,6 +171,8 @@ class SQLLintError(SQLBaseError):
             used for logging and for referencing position.
 
     """
+    _identifier = 'linting'
+
     def __init__(self, *args, **kwargs):
         # Something about position, message and fix?
         self.segment = kwargs.pop('segment', None)

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -606,6 +606,10 @@ class Linter:
             vs += linting_errors
             fixed_buff = parsed.raw
 
+        # We process the ignore config here if appropriate
+        for violation in vs:
+            violation.ignore_if_in(config.get('ignore'))
+
         file_mask = (raw_buff, templ_buff, fixed_buff)
         res = LintedFile(fname, vs, time_dict, parsed,
                          file_mask=file_mask)

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -607,8 +607,9 @@ class Linter:
             fixed_buff = parsed.raw
 
         # We process the ignore config here if appropriate
-        for violation in vs:
-            violation.ignore_if_in(config.get('ignore'))
+        if config:
+            for violation in vs:
+                violation.ignore_if_in(config.get('ignore'))
 
         file_mask = (raw_buff, templ_buff, fixed_buff)
         res = LintedFile(fname, vs, time_dict, parsed,

--- a/src/sqlfluff/parser/lexer.py
+++ b/src/sqlfluff/parser/lexer.py
@@ -199,10 +199,10 @@ class Lexer:
                 if not resort_res:
                     # If we STILL can't match, then just panic out.
                     raise violations[-1]
-                else:
-                    raw = resort_res.new_string
-                    start_pos = resort_res.new_pos
-                    segment_buff += resort_res.segments
+
+                raw = resort_res.new_string
+                start_pos = resort_res.new_pos
+                segment_buff += resort_res.segments
             else:
                 break
         return segment_buff, violations

--- a/src/sqlfluff/parser/lexer.py
+++ b/src/sqlfluff/parser/lexer.py
@@ -163,26 +163,46 @@ class Lexer:
     This class is likely called directly from a top level segment
     such as the `FileSegment`.
     """
-    def __init__(self, config):
+    def __init__(self, config, last_resort_lexer=None):
         # config is required - we use it to get the dialect
         self.config = config
         lexer_struct = config.get('dialect_obj').get_lexer_struct()
         self.matcher = RepeatedMultiMatcher.from_struct(lexer_struct)
+        self.last_resort_lexer = last_resort_lexer or RegexMatcher.from_shorthand(
+            '<unlexable>', r'[^\t\n\,\.\ \-\+\*\\\/\'\"\;\:\[\]\(\)\|]*',
+            is_code=True
+        )
 
     def lex(self, raw):
         """Take a string and return segments.
 
         If we fail to match the *whole* string, then we must have
-        found something that we cannot lex. This should raise a
-        `SQLLexError`, which we expect will be caught by whichever
-        CLI command launched this.
+        found something that we cannot lex. If that happens we should
+        package it up as unlexable and keep track of the exceptions.
         """
         start_pos = FilePositionMarker.from_fresh()
-        res = self.matcher.match(raw, start_pos)
-        if len(res.new_string) > 0:
-            raise SQLLexError(
-                "Unable to lex characters: '{0!r}...'".format(
-                    res.new_string[:10]),
-                pos=res.new_pos
-            )
-        return res.segments
+        segment_buff = ()
+        violations = []
+
+        while True:
+            res = self.matcher.match(raw, start_pos)
+            segment_buff += res.segments
+            if len(res.new_string) > 0:
+                violations.append(SQLLexError(
+                    "Unable to lex characters: '{0!r}...'".format(
+                        res.new_string[:10]),
+                    pos=res.new_pos
+                ))
+                resort_res = self.last_resort_lexer.match(
+                    res.new_string, res.new_pos
+                )
+                if not resort_res:
+                    # If we STILL can't match, then just panic out.
+                    raise violations[-1]
+                else:
+                    raw = resort_res.new_string
+                    start_pos = resort_res.new_pos
+                    segment_buff += resort_res.segments
+            else:
+                break
+        return segment_buff, violations

--- a/src/sqlfluff/parser/segments_file.py
+++ b/src/sqlfluff/parser/segments_file.py
@@ -27,5 +27,5 @@ class FileSegment(BaseSegment):
         if config is None:
             raise ValueError("Config is required for from_raw to fetch lexing dialect.")
         lexer = Lexer(config=config)
-        segments = lexer.lex(raw)
-        return cls(segments=segments)
+        segments, violations = lexer.lex(raw)
+        return cls(segments=segments), violations

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -778,12 +778,17 @@ class Rule_L010(BaseCrawler):
 
     """
 
-    _target_elem = 'keyword'
+    # Binary operators behave like keywords too.
+    _target_elems = ('keyword', 'binary_operator')
 
     def __init__(self, capitalisation_policy='consistent', **kwargs):
         """Initialise, extracting the capitalisation mode from the config."""
-        if capitalisation_policy not in ('consistent', 'upper', 'lower', 'capitalise'):
-            raise ValueError("Unexpected capitalisation_policy: {0!r}".format(capitalisation_policy))
+        capitalisation_options = ('consistent', 'upper', 'lower', 'capitalise')
+        if capitalisation_policy not in capitalisation_options:
+            raise ValueError(
+                ("Unexpected capitalisation_policy for rule {1}: {0!r}\nShould "
+                 "be one of: {2!r}").format(capitalisation_policy, self.__class__.__name__,
+                                            capitalisation_options))
         self.capitalisation_policy = capitalisation_policy
         super(Rule_L010, self).__init__(**kwargs)
 
@@ -796,7 +801,7 @@ class Rule_L010(BaseCrawler):
         """
         cases_seen = memory.get('cases_seen', set())
 
-        if segment.type == self._target_elem:
+        if segment.type in self._target_elems:
             raw = segment.raw
             uc = raw.upper()
             lc = raw.lower()
@@ -885,7 +890,7 @@ class Rule_L010(BaseCrawler):
 class Rule_L011(BaseCrawler):
     """Implicit aliasing of table not allowed. Use explicit `AS` clause."""
 
-    _target_elem = 'table_expression'
+    _target_elems = ('table_expression',)
 
     def _eval(self, segment, parent_stack, raw_stack, **kwargs):
         """Implicit aliasing of table/column not allowed. Use explicit `AS` clause.
@@ -897,7 +902,7 @@ class Rule_L011(BaseCrawler):
 
         """
         if segment.type == 'alias_expression':
-            if parent_stack[-1].type == self._target_elem:
+            if parent_stack[-1].type in self._target_elems:
                 if not any(e.name.lower() == 'as' for e in segment.segments):
                     insert_buff = []
                     insert_str = ''
@@ -938,7 +943,7 @@ class Rule_L012(Rule_L011):
 
     """
 
-    _target_elem = 'select_target_element'
+    _target_elems = ('select_target_element',)
 
 
 @std_rule_set.register
@@ -1001,7 +1006,7 @@ class Rule_L014(Rule_L010):
 
     """
 
-    _target_elem = 'naked_identifier'
+    _target_elems = ('naked_identifier',)
 
 
 @std_rule_set.register

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -55,25 +55,6 @@ def test__cli__command_dialect():
     )
 
 
-def test__cli__fix_with_problems():
-    """Check the script doesn't raise an unexpected exception with badly formed files."""
-    invoke_assert_code(
-        args=[fix, ['--rules', 'L001', 'test/fixtures/cli/fail_many.sql', '-vvvvvvv'], 'y']
-    )
-
-
-def test__cli__command_lint():
-    """Check basic commands on a simple script."""
-    # Not verbose
-    invoke_assert_code(args=[lint, ['-n', 'test/fixtures/cli/passing_a.sql']])
-    # Verbose
-    invoke_assert_code(args=[lint, ['-n', '-v', 'test/fixtures/cli/passing_a.sql']])
-    # Very Verbose
-    invoke_assert_code(args=[lint, ['-n', '-vvvv', 'test/fixtures/cli/passing_a.sql']])
-    # Very Verbose (Colored)
-    invoke_assert_code(args=[lint, ['-vvvv', 'test/fixtures/cli/passing_a.sql']])
-
-
 @pytest.mark.parametrize('command', [
     ('-', '-n', ), ('-', '-n', '-v',), ('-', '-n', '-vv',), ('-', '-vv',),
 ])
@@ -90,6 +71,11 @@ def test__cli__command_lint_stdin(command):
 @pytest.mark.parametrize('command', [
     # Test basic linting
     (lint, ['-n', 'test/fixtures/cli/passing_b.sql']),
+    # Original tests from test__cli__command_lint
+    (lint, ['-n', 'test/fixtures/cli/passing_a.sql']),
+    (lint, ['-n', '-v', 'test/fixtures/cli/passing_a.sql']),
+    (lint, ['-n', '-vvvv', 'test/fixtures/cli/passing_a.sql']),
+    (lint, ['-vvvv', 'test/fixtures/cli/passing_a.sql']),
     # Test basic linting with very high verbosity
     (lint, ['-n', 'test/fixtures/cli/passing_b.sql', '-vvvvvvvvvvv']),
     # Check basic parsing
@@ -108,7 +94,11 @@ def test__cli__command_lint_stdin(command):
     # Check linting works with both included and excluded rules
     (lint, ['-n', '--rules', 'L001,L006', '--exclude-rules', 'L006', 'test/fixtures/linter/operator_errors.sql']),
     # Check linting works with just excluded rules
-    (lint, ['-n', '--exclude-rules', 'L006,L007', 'test/fixtures/linter/operator_errors.sql'])
+    (lint, ['-n', '--exclude-rules', 'L006,L007', 'test/fixtures/linter/operator_errors.sql']),
+    # Check the script doesn't raise an unexpected exception with badly formed files.
+    (fix, ['--rules', 'L001', 'test/fixtures/cli/fail_many.sql', '-vvvvvvv'], 'y'),
+    # Check that ignoring works (also checks that unicode files parse).
+    (lint, ['-n', '--exclude-rules', 'L003,L009', '--ignore', 'parsing,lexing', 'test/fixtures/linter/parse_lex_error.sql']),
 ])
 def test__cli__command_lint_parse(command):
     """Check basic commands on a more complicated script."""

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -20,7 +20,7 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
     """Test we don't drop bits on simple examples."""
     config = FluffConfig(overrides=dict(dialect='ansi'))
     with caplog.at_level(logging.DEBUG):
-        fs = FileSegment.from_raw(raw, config=config)
+        fs, _ = FileSegment.from_raw(raw, config=config)
     # From just the initial parse, check we're all there
     assert fs.raw == raw
     assert fs.raw_list() == res
@@ -99,7 +99,9 @@ def test__dialect__ansi_specific_segment_parses(segmentref, raw, caplog):
     # Lex the string for matching. For a good test, this would
     # arguably happen as a fixture, but it's easier to pass strings
     # as parameters than pre-lexed segment strings.
-    seg_list = lex.lex(raw)
+    seg_list, vs = lex.lex(raw)
+    assert not vs
+
     print(seg_list)
     # Get the segment class for matching
     Seg = config.get('dialect_obj').ref(segmentref)

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -78,7 +78,10 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
         ("SelectStatementSegment", "SELECT t.val/t.id FROM test WHERE id*1.0/id > 0.8"),
         # Issue with casting raise as part of PR #177
         ("SelectTargetElementSegment",
-         "CAST(num AS INT64)")
+         "CAST(num AS INT64)"),
+        # Casting as datatype with arguments
+        ("SelectTargetElementSegment",
+         "CAST(num AS numeric(8,4))")
     ]
 )
 def test__dialect__ansi_specific_segment_parses(segmentref, raw, caplog):

--- a/test/dialects_test.py
+++ b/test/dialects_test.py
@@ -54,9 +54,12 @@ def test__dialect__base_file_parse(dialect, file):
     # Load the right dialect
     config = FluffConfig(overrides=dict(dialect=dialect))
     context = ParseContext.from_config(config)
-    fs = FileSegment.from_raw(raw, config=config)
+    fs, lex_vs = FileSegment.from_raw(raw, config=config)
     # From just the initial parse, check we're all there
     assert fs.raw == raw
+    # Check we don't have lexing issues
+    assert not lex_vs
+
     # Do the parse WITHOUT lots of logging
     # The logs get too long here to be useful. We should use
     # specfic segment tests if we want to debug logs.
@@ -84,7 +87,7 @@ def test__dialect__base_parse_struct(dialect, sqlfile, yamlfile, yaml_loader):
     context = ParseContext.from_config(config)
     # Load the SQL
     raw = load_file(dialect, sqlfile)
-    fs = FileSegment.from_raw(raw, config=config)
+    fs, _ = FileSegment.from_raw(raw, config=config)
     # Load the YAML
     res = yaml_loader(make_dialect_path(dialect, yamlfile))
     # with caplog.at_level(logging.DEBUG):

--- a/test/fixtures/linter/operator_errors.sql
+++ b/test/fixtures/linter/operator_errors.sql
@@ -6,5 +6,5 @@ SELECT
     a.a AS bad_3,
     2+(3+6)+7 AS bad_4,
     a.b
-    and a.a AS good_4
+    AND a.a AS good_4
 FROM tbl AS a

--- a/test/fixtures/linter/parse_lex_error.sql
+++ b/test/fixtures/linter/parse_lex_error.sql
@@ -1,0 +1,10 @@
+-- file with both parsing and lexing errors.
+-- Used for checking ignore functionality and
+-- the ability to work around issues.
+SELECT
+   a.id, -- 3 Spaces
+    a.name,
+    a.training_spaces,
+    some_function(SELECT LIMIT WHERE BY ORDER) AS not_parsable,
+    another_function(🤷‍♀️) AS not_lexable
+FROM tbl AS a

--- a/test/fixtures/parser/ansi/grant_all_on_table_mytable_to_role.sql
+++ b/test/fixtures/parser/ansi/grant_all_on_table_mytable_to_role.sql
@@ -1,1 +1,1 @@
-grant all on table mytable to role
+grant all on table mytable to myrole

--- a/test/fixtures/parser/ansi/grant_all_privileges_on_mytable_to_role.sql
+++ b/test/fixtures/parser/ansi/grant_all_privileges_on_mytable_to_role.sql
@@ -1,1 +1,1 @@
-grant all privileges on mytable to role
+grant all privileges on mytable to myrole

--- a/test/fixtures/parser/ansi/select_simple_e.yml
+++ b/test/fixtures/parser/ansi/select_simple_e.yml
@@ -10,7 +10,8 @@ file:
               naked_identifier: my_var
             cast_expression:
               casting_operator: '::'
-              data_type: date
+              data_type:
+                data_type_identifier: date
           alias_expression:
             keyword: as
             naked_identifier: casted_variable
@@ -20,7 +21,8 @@ file:
             numeric_literal: 123
             cast_expression:
               casting_operator: '::'
-              data_type: bigint
+              data_type:
+                data_type_identifier: bigint
           alias_expression:
             keyword: as
             naked_identifier: another_casted_number

--- a/test/fixtures/parser/ansi/select_simple_j.sql
+++ b/test/fixtures/parser/ansi/select_simple_j.sql
@@ -1,7 +1,9 @@
--- test parsing of cross join
+-- test parsing of cross join and outer join
 SELECT
     count_correctly_substituted
 FROM
     correctly_substituted
 CROSS JOIN
     needs_substitution
+LEFT OUTER JOIN
+    some_other_table

--- a/test/fixtures/parser/ansi/select_simple_j.yml
+++ b/test/fixtures/parser/ansi/select_simple_j.yml
@@ -8,13 +8,20 @@ file:
           object_reference:
             naked_identifier: count_correctly_substituted
       from_clause:
-        keyword: FROM
-        table_expression:
-          object_reference:
-            naked_identifier: correctly_substituted
-        join_clause:
-        - keyword: CROSS
-        - keyword: JOIN
+        - keyword: FROM
         - table_expression:
             object_reference:
-              naked_identifier: needs_substitution
+              naked_identifier: correctly_substituted
+        - join_clause:
+          - keyword: CROSS
+          - keyword: JOIN
+          - table_expression:
+              object_reference:
+                naked_identifier: needs_substitution
+        - join_clause:
+          - keyword: LEFT
+          - keyword: OUTER
+          - keyword: JOIN
+          - table_expression:
+              object_reference:
+                naked_identifier: some_other_table


### PR DESCRIPTION
Fixes #104 

Includes the boolean binary operators `AND`, `OR` etc... in the linting rule about consistent capitalisation.

Also fixes a couple of minor parsing bugs found during testing.