### PR TITLE
Add output format option for linter, json support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ env
 .tox
 venv
 .venv 
+.python-version
 
 # Ignore coverage reports
 .coverage

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -1,6 +1,7 @@
 """Contains the CLI."""
 
 import sys
+import json
 
 import click
 # For the profiler
@@ -111,8 +112,11 @@ def rules(**kwargs):
 
 @cli.command()
 @common_options
+@click.option('-f', '--format', 'format', default='human',
+              type=click.Choice(['human', 'json'], case_sensitive=False),
+              help='What format to return the lint result in.')
 @click.argument('paths', nargs=-1)
-def lint(paths, **kwargs):
+def lint(paths, format, **kwargs):
     """Lint SQL files via passing a list of files or using stdin.
 
     PATH is the path to a sql file or directory to lint. This can be either a
@@ -132,12 +136,13 @@ def lint(paths, **kwargs):
 
     """
     c = get_config(**kwargs)
-    lnt = get_linter(c)
+    lnt = get_linter(c, silent=format == 'json')
     verbose = c.get('verbose')
 
     config_string = format_config(lnt, verbose=verbose)
     if len(config_string) > 0:
         lnt.log(config_string)
+
     # add stdin if specified via lone '-'
     if ('-',) == paths:
         result = lnt.lint_string_wrapped(sys.stdin.read(), fname='stdin', verbosity=verbose)
@@ -151,6 +156,10 @@ def lint(paths, **kwargs):
             sys.exit(1)
         # Output the final stats
         lnt.log(format_linting_result_footer(result, verbose=verbose))
+
+    if format == 'json':
+        click.echo(json.dumps(result.as_records()))
+
     sys.exit(result.stats()['exit code'])
 
 

--- a/src/sqlfluff/errors.py
+++ b/src/sqlfluff/errors.py
@@ -98,6 +98,7 @@ class SQLBaseError(ValueError):
 
     def get_info_dict(self):
         """Get a dictionary representation of this violation.
+
         Returns:
             A `dictionary` with keys (code, line_no, line_pos, description)
         """

--- a/src/sqlfluff/errors.py
+++ b/src/sqlfluff/errors.py
@@ -96,6 +96,16 @@ class SQLBaseError(ValueError):
         """
         return self.rule_code(), self.line_no(), self.line_pos(), self.desc()
 
+    def get_info_dict(self):
+        """Get a dictionary representation of this violation.
+        Returns:
+            A `dictionary` with keys (code, line_no, line_pos, description)
+        """
+        return dict(zip(
+            ('code', 'line_no', 'line_pos', 'description'),
+            self.get_info_tuple()
+        ))
+
     def ignore_if_in(self, ignore_iterable):
         """Ignore this violation if it matches the iterable."""
         # Type conversion

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -386,6 +386,20 @@ class LintingResult:
         all_stats['status'] = 'FAIL' if all_stats['violations'] > 0 else 'PASS'
         return all_stats
 
+    def as_records(self):
+        """Return the result as a list of dictionaries.
+
+        Each record contains a key specifying the filepath, and a list of violations. This
+        method is useful for serialization as all objects will be builtin python types
+        (ints, strs).
+        """
+        return [
+            {'filepath': path, 'violations': [v.get_info_dict() for v in violations]}
+            for lintedpath in self.paths
+            for path, violations in lintedpath.violations().items()
+            if violations
+        ]
+
     def persist_changes(self, verbosity=0, output_func=None, **kwargs):
         """Run all the fixes for all the files and return a dict."""
         return self.combine_dicts(

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -4,6 +4,7 @@ import configparser
 import tempfile
 import os
 import shutil
+import json
 
 # Testing libraries
 import pytest
@@ -210,3 +211,44 @@ def test__cli__command__fix_no_force(rule, fname, prompt, exit_code):
         generic_roundtrip_test(
             test_file, rule, force=False, final_exit_code=exit_code,
             fix_input=prompt)
+
+
+@pytest.mark.parametrize('sql,expected,exit_code', [
+    ('select * from tbl', [], 0),  # empty list if no violations
+    (
+        'SElect * from tbl',
+        [{
+            "filepath": "stdin",
+            "violations": [
+                {
+                    "code": "L010",
+                    "line_no": 1,
+                    "line_pos": 1,
+                    "description": "Inconsistent capitalisation of keywords."
+                }
+            ]
+        }],
+        65
+    )
+])
+def test__cli__command_lint_json_from_stdin(sql, expected, exit_code):
+    """Check an explicit JSON return value for a single error."""
+    result = invoke_assert_code(
+        args=[lint, ('-', '--rules', 'L010', '--format', 'json')],
+        cli_input=sql,
+        ret_code=exit_code
+    )
+    assert json.loads(result.output) == expected
+
+
+def test__cli__command_lint_json_multiple_files():
+    """Check the general format of JSON output for multiple files."""
+    fpath = 'test/fixtures/linter/indentation_errors.sql'
+
+    # note the file is in here twice. two files = two payloads.
+    result = invoke_assert_code(
+        args=[lint, (fpath, fpath, '--format', 'json')],
+        ret_code=65,
+    )
+    result = json.loads(result.output)
+    assert len(result) == 2


### PR DESCRIPTION
This is very much a discussion starter! Fixes #100 .

## Adding JSON support to the linter.

I set up an output format conditional in `lint_string()`, and propagated an `out_format` flag from there to the CLI.

When `out_format='json'`, the linter prints out each file's violations as a JSON payload on a single line. 

In the CLI:

```sh
$ echo 'SElect * from tbl' | sqlfluff lint - --out-format json --rules L010
{"filepath": "stdin", "violations": [{"code": "L010", "line_no": 1, "line_pos": 1, "description": "Inconsistent capitalisation of keywords."}]}
```

With multiple files, the full CLI output is not JSON interpretable. This is because the linter's CLI output is incremental, so there is not currently an easy way to construct a multi-file payload. 

```sh
$ sqlfluff lint test/fixtures/linter/indentation_errors.sql test/fixtures/linter/parse_error.sql --out-format json --rules L010 
{"filepath": "test/fixtures/linter/indentation_errors.sql", "violations": [{"code": "L010", "line_no": 6, "line_pos": 10, "description": "Inconsistent capitalisation of keywords."}]}
{"filepath": "test/fixtures/linter/parse_error.sql", "violations": [{"code": "PRS", "line_no": 1, "line_pos": 1, "description": "Found unparsable segment @L001P001: 'SELECT\\n...'"}]}
```

Each line of the output corresponds to a single file and is JSON interpretable though, so you can:

```python
[json.loads(i) for i in result.split('\n') if i.strip()]
```

## Points to discuss

This is very much a first draft. If it is acceptable, then great 🍻!  Here are some of my concerns:

1. I approached this in a minimum-viable-change kind of way. I figured out what lint_string needed to know and then propagated that all the way to the user interface. Should `out_format` be a part of the linter configuration? 
2. I do not know how `verbosity` and `out_format` interact. My intuition is that verbosity is not relevant when you want JSON, should a warning be raised when setting both?
3. The argument lists for some of the core methods are getting very long. How can we prevent flags/complexity from multiplying every time new functionality is desired?
