### PR TITLE
Consistent yaml and json output on parse and lint

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -3,6 +3,8 @@
 import sys
 import json
 
+import oyaml as yaml
+
 import click
 # For the profiler
 import pstats
@@ -113,7 +115,7 @@ def rules(**kwargs):
 @cli.command()
 @common_options
 @click.option('-f', '--format', 'format', default='human',
-              type=click.Choice(['human', 'json'], case_sensitive=False),
+              type=click.Choice(['human', 'json', 'yaml'], case_sensitive=False),
               help='What format to return the lint result in.')
 @click.argument('paths', nargs=-1)
 def lint(paths, format, **kwargs):
@@ -136,7 +138,7 @@ def lint(paths, format, **kwargs):
 
     """
     c = get_config(**kwargs)
-    lnt = get_linter(c, silent=format == 'json')
+    lnt = get_linter(c, silent=format in ('json', 'yaml'))
     verbose = c.get('verbose')
 
     config_string = format_config(lnt, verbose=verbose)
@@ -159,6 +161,8 @@ def lint(paths, format, **kwargs):
 
     if format == 'json':
         click.echo(json.dumps(result.as_records()))
+    elif format == 'yaml':
+        click.echo(yaml.dump(result.as_records()))
 
     sys.exit(result.stats()['exit code'])
 
@@ -257,7 +261,7 @@ def fix(force, paths, **kwargs):
 @click.option('-c', '--code-only', is_flag=True,
               help='Output only the code elements of the parse tree.')
 @click.option('-f', '--format', default='human',
-              type=click.Choice(['human', 'yaml'], case_sensitive=False),
+              type=click.Choice(['human', 'json', 'yaml'], case_sensitive=False),
               help='What format to return the parse result in.')
 @click.option('--profiler', is_flag=True,
               help='Set this flag to engage the python profiler.')
@@ -271,7 +275,7 @@ def parse(path, code_only, format, profiler, **kwargs):
     """
     c = get_config(**kwargs)
     # We don't want anything else to be logged if we want a yaml output
-    lnt = get_linter(c, silent=format == 'yaml')
+    lnt = get_linter(c, silent=format in ('json', 'yaml'))
     verbose = c.get('verbose')
     recurse = c.get('recurse')
 
@@ -290,23 +294,54 @@ def parse(path, code_only, format, profiler, **kwargs):
             sys.exit(1)
         pr = cProfile.Profile()
         pr.enable()
+
     try:
-        # A single path must be specified for this command
-        for parsed, violations, time_dict in lnt.parse_path(path, verbosity=verbose, recurse=recurse):
-            if parsed:
-                if format == 'human':
+        # handle stdin if specified via lone '-'
+        if '-' == path:
+            # put the parser result in a list to iterate later
+            config = lnt.config.make_child_from_path('stdin')
+            result = [lnt.parse_string(
+                sys.stdin.read(),
+                'stdin',
+                verbosity=verbose,
+                recurse=recurse,
+                config=config
+            )]
+        else:
+            # A single path must be specified for this command
+            result = lnt.parse_path(path, verbosity=verbose, recurse=recurse)
+
+        # iterative print for human readout
+        if format == 'human':
+            for parsed, violations, time_dict in result:
+                if parsed:
                     lnt.log(parsed.stringify(code_only=code_only))
-                elif format == 'yaml':
-                    click.echo(parsed.to_yaml(code_only=code_only, show_raw=True))
-            else:
-                # TODO: Make this prettier
-                lnt.log('...Failed to Parse...')
-            nv += len(violations)
-            for v in violations:
-                lnt.log(format_violation(v, verbose=verbose))
-            if verbose >= 2:
-                lnt.log("==== timings ====")
-                lnt.log(cli_table(time_dict.items()))
+                else:
+                    # TODO: Make this prettier
+                    lnt.log('...Failed to Parse...')
+                nv += len(violations)
+                for v in violations:
+                    lnt.log(format_violation(v, verbose=verbose))
+                if verbose >= 2:
+                    lnt.log("==== timings ====")
+                    lnt.log(cli_table(time_dict.items()))
+        else:
+            # collect result and print as single payload
+            # will need to zip in the file paths
+            filepaths = ['stdin'] if '-' == path else lnt.paths_from_path(path)
+            result = [
+                dict(
+                    filepath=filepath,
+                    segments=parsed.as_record(code_only=code_only, show_raw=True)
+                )
+                for filepath, (parsed, _, _) in zip(filepaths, result)
+            ]
+
+            if format == 'yaml':
+                click.echo(yaml.dump(result))
+            elif format == 'json':
+                click.echo(json.dumps(result))
+
     except IOError:
         click.echo(colorize('The path {0!r} could not be accessed. Check it exists.'.format(path), 'red'))
         sys.exit(1)

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -13,7 +13,7 @@ These are the fundamental building blocks of the rest of the parser.
 """
 
 import logging
-import oyaml as yaml
+
 from io import StringIO
 
 from .match import MatchResult, curtail_string, join_segments_raw
@@ -522,31 +522,33 @@ class BaseSegment:
             result = (self.type, tuple(seg.to_tuple(**kwargs) for seg in self.segments if not seg.is_meta))
         return result
 
-    def to_yaml(self, **kwargs):
-        """Return a yaml structure from this segment."""
-        tpl = self.to_tuple(**kwargs)
+    @classmethod
+    def structural_simplify(cls, elem):
+        """Simplify the structure recursively so it serializes nicely in json/yaml."""
+        if isinstance(elem, tuple):
+            # Does this look like an element?
+            if len(elem) == 2 and isinstance(elem[0], str):
+                # This looks like a single element, make a dict
+                elem = {elem[0]: cls.structural_simplify(elem[1])}
+            elif isinstance(elem[0], tuple):
+                # This looks like a list of elements.
+                keys = [e[0] for e in elem]
+                # Any duplicate elements?
+                if len(set(keys)) == len(keys):
+                    # No, we can use a mapping typle
+                    elem = {e[0]: cls.structural_simplify(e[1]) for e in elem}
+                else:
+                    # Yes, this has to be a list :(
+                    elem = [cls.structural_simplify(e) for e in elem]
+        return elem
 
-        def _structural_simplify(elem):
-            """Simplify the structure recursively so it outputs nicely in yaml."""
-            if isinstance(elem, tuple):
-                # Does this look like an element?
-                if len(elem) == 2 and isinstance(elem[0], str):
-                    # This looks like a single element, make a dict
-                    elem = {elem[0]: _structural_simplify(elem[1])}
-                elif isinstance(elem[0], tuple):
-                    # This looks like a list of elements.
-                    keys = [e[0] for e in elem]
-                    # Any duplicate elements?
-                    if len(set(keys)) == len(keys):
-                        # No, we can use a mapping typle
-                        elem = {e[0]: _structural_simplify(e[1]) for e in elem}
-                    else:
-                        # Yes, this has to be a list :(
-                        elem = [_structural_simplify(e) for e in elem]
-            return elem
+    def as_record(self, **kwargs):
+        """Return the segment as a structurally simplified record.
 
-        obj = _structural_simplify(tpl)
-        return yaml.dump(obj)
+        This is useful for serialization to yaml or json.
+        kwargs passed to to_tuple
+        """
+        return self.structural_simplify(self.to_tuple(**kwargs))
 
     @classmethod
     def match(cls, segments, parse_context):

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -5,6 +5,7 @@ import tempfile
 import os
 import shutil
 import json
+import oyaml as yaml
 
 # Testing libraries
 import pytest
@@ -213,6 +214,27 @@ def test__cli__command__fix_no_force(rule, fname, prompt, exit_code):
             fix_input=prompt)
 
 
+@pytest.mark.parametrize('serialize', ['yaml', 'json'])
+def test__cli__command_parse_serialize_from_stdin(serialize):
+    """Check that the parser serialized output option is working.
+
+    Not going to test for the content of the output as that is subject to change.
+    """
+    result = invoke_assert_code(
+        args=[parse, ('-', '--format', serialize)],
+        cli_input='select * from tbl',
+    )
+    if serialize == 'json':
+        result = json.loads(result.output)
+    elif serialize == 'yaml':
+        result = yaml.load(result.output)
+    else:
+        raise Exception
+    result = result[0]  # only one file
+    assert result['filepath'] == 'stdin'
+
+
+@pytest.mark.parametrize('serialize', ['yaml', 'json'])
 @pytest.mark.parametrize('sql,expected,exit_code', [
     ('select * from tbl', [], 0),  # empty list if no violations
     (
@@ -231,24 +253,37 @@ def test__cli__command__fix_no_force(rule, fname, prompt, exit_code):
         65
     )
 ])
-def test__cli__command_lint_json_from_stdin(sql, expected, exit_code):
-    """Check an explicit JSON return value for a single error."""
+def test__cli__command_lint_serialize_from_stdin(serialize, sql, expected, exit_code):
+    """Check an explicit serialized return value for a single error."""
     result = invoke_assert_code(
-        args=[lint, ('-', '--rules', 'L010', '--format', 'json')],
+        args=[lint, ('-', '--rules', 'L010', '--format', serialize)],
         cli_input=sql,
         ret_code=exit_code
     )
-    assert json.loads(result.output) == expected
+
+    if serialize == 'json':
+        assert json.loads(result.output) == expected
+    elif serialize == 'yaml':
+        assert yaml.load(result.output) == expected
+    else:
+        raise Exception
 
 
-def test__cli__command_lint_json_multiple_files():
+@pytest.mark.parametrize('serialize', ['yaml', 'json'])
+def test__cli__command_lint_serialize_multiple_files(serialize):
     """Check the general format of JSON output for multiple files."""
     fpath = 'test/fixtures/linter/indentation_errors.sql'
 
     # note the file is in here twice. two files = two payloads.
     result = invoke_assert_code(
-        args=[lint, (fpath, fpath, '--format', 'json')],
+        args=[lint, (fpath, fpath, '--format', serialize)],
         ret_code=65,
     )
-    result = json.loads(result.output)
+
+    if serialize == 'json':
+        result = json.loads(result.output)
+    elif serialize == 'yaml':
+        result = yaml.load(result.output)
+    else:
+        raise Exception
     assert len(result) == 2


### PR DESCRIPTION
Fixes #197 

1.  Add a stdin handler for parse (this was missing!)
2. add yaml option for lint
3. add json option for parse

To support general serialization of the parse result to json or yaml, I needed to change how the printing was done.

For human output, printing is incremental and done via a generator. The logger prints out the file name separately from the parsed segments.

For JSON/YAML output, we need to collect everything together at one time and dump it. We also need to add the file path as that is not connected to the BaseSegment at all. 

As a result the parse command logic has gotten more complex, and serialization logic was moved from BaseSegment to the CLI handler. @alanmcruickshank please let me know if this fits with your vision of the project!
