### PR TITLE
Add __main__ interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- For the `parse` command the `--profiler` option to help debugging
+  performance issues.
+
+### Changed
+
+- Validation of the match results of grammars has been reduced. In
+  production cases the validation will still be done, but only on
+  *parse* and not on *match*.
+- At low verbosities, python level logging is also reduced.
+
 ## [0.3.1] - 2020-02-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2020-02-17
+
+### Added
+
+- Support for `a.b.*` on top of `a.*` in select target expressions.
+
 ## [0.3.0] - 2020-02-15
 
 ### Changed

--- a/src/sqlfluff/__main__.py
+++ b/src/sqlfluff/__main__.py
@@ -1,0 +1,5 @@
+"""Export cli to __main__ for use like python -m sqfluff."""
+from .cli.commands import cli
+
+if __name__ == "__main__":
+    cli()

--- a/src/sqlfluff/config.ini
+++ b/src/sqlfluff/config.ini
@@ -1,3 +1,3 @@
 # Config file for sqlfluff, mostly for version info for now
 [sqlfluff]
-version=0.3.0
+version=0.3.1

--- a/src/sqlfluff/default_config.cfg
+++ b/src/sqlfluff/default_config.cfg
@@ -12,6 +12,7 @@ recurse = 0
 dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
 dbt_source = {% macro source(source_name, table) %}{{source_name}}_{{table}}{% endmacro %}
 dbt_config = {% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %}
+dbt_var = {% macro var(variable) %}item{% endmacro %}
 
 # Some rules can be configured directly from the config common to other rules.
 [sqlfluff:rules]

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -491,8 +491,15 @@ class SelectTargetElementSegment(BaseSegment):
     parse_grammar = OneOf(
         # *
         Ref('StarSegment'),
-        # blah.*
-        Sequence(Ref('SingleIdentifierGrammar'), Ref('DotSegment'), Ref('StarSegment'), code_only=False),
+        # blah.* + blah.blah.*
+        Sequence(
+            Ref('SingleIdentifierGrammar'), Ref('DotSegment'),
+            Sequence(
+                Ref('SingleIdentifierGrammar'), Ref('DotSegment'),
+                optional=True
+            ),
+            Ref('StarSegment'), code_only=False
+        ),
         Sequence(
             OneOf(
                 Ref('LiteralGrammar'),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -494,7 +494,8 @@ class SelectTargetElementSegment(BaseSegment):
             AnyNumberOf(
                 Sequence(
                     Ref('SingleIdentifierGrammar'),
-                    Ref('DotSegment')
+                    Ref('DotSegment'),
+                    code_only=True
                 )
             ),
             Ref('StarSegment'), code_only=False

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -489,14 +489,13 @@ class SelectTargetElementSegment(BaseSegment):
     # Important to split elements before parsing, otherwise debugging is really hard.
     match_grammar = GreedyUntil(Ref('CommaSegment'))
     parse_grammar = OneOf(
-        # *
-        Ref('StarSegment'),
-        # blah.* + blah.blah.*
+        # *, blah.*, blah.blah.*, etc.
         Sequence(
-            Ref('SingleIdentifierGrammar'), Ref('DotSegment'),
-            Sequence(
-                Ref('SingleIdentifierGrammar'), Ref('DotSegment'),
-                optional=True
+            AnyNumberOf(
+                Sequence(
+                    Ref('SingleIdentifierGrammar'),
+                    Ref('DotSegment')
+                )
             ),
             Ref('StarSegment'), code_only=False
         ),

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -690,5 +690,7 @@ class Linter:
         for fname in self.paths_from_path(path):
             self.log('=== [\u001b[30;1m{0}\u001b[0m] ==='.format(fname))
             config = self.config.make_child_from_path(fname)
-            with open(fname, 'r') as f:
-                yield self.parse_string(f.read(), fname=fname, verbosity=verbosity, recurse=recurse, config=config)
+            # Handle unicode issues gracefully
+            with open(fname, 'r', encoding='utf8', errors='backslashreplace') as target_file:
+                yield self.parse_string(target_file.read(), fname=fname, verbosity=verbosity,
+                                        recurse=recurse, config=config)

--- a/src/sqlfluff/parser/grammar.py
+++ b/src/sqlfluff/parser/grammar.py
@@ -422,8 +422,11 @@ class Ref(BaseGrammar):
             raise ValueError("Null Element returned! _elements: {0!r}".format(self._elements))
 
         # First check against the efficiency Cache.
-        # Make a tuple of the incoming segments
-        seg_tuple = BaseSegment.segs_to_tuple(segments, show_raw=True)
+        # We used to use seg_to_tuple here, but it was too slow,
+        # so instead we rely on segments not being mutated within a given
+        # match cycle and so the ids should continue to refer to unchanged
+        # objects.
+        seg_tuple = (id(seg) for seg in segments)
         self_name = self._get_ref()
         if parse_context.blacklist.check(self_name, seg_tuple):
             # This has been tried before.

--- a/src/sqlfluff/parser/grammar.py
+++ b/src/sqlfluff/parser/grammar.py
@@ -68,12 +68,15 @@ class BaseGrammar:
             logging.info("{0}.match, was passed zero length segments list. NB: {0} contains {1!r}".format(
                 self.__class__.__name__, self._elements))
 
-        # Work out the raw representation and curtail if long
-        parse_match_logging(
-            self.__class__.__name__, '_match', 'IN', parse_context=parse_context,
-            v_level=self.v_level,
-            le=len(self._elements), ls=len(segments),
-            seg=join_segments_raw_curtailed(segments))
+        # If we can avoid this, bank the performance increase.
+        if parse_context.verbosity > 1:
+            # Logging to help with debugging.
+            # Work out the raw representation and curtail if long.
+            parse_match_logging(
+                self.__class__.__name__, '_match', 'IN', parse_context=parse_context,
+                v_level=self.v_level,
+                le=len(self._elements), ls=len(segments),
+                seg=join_segments_raw_curtailed(segments))
 
         m = self.match(segments, parse_context=parse_context)
 
@@ -93,12 +96,14 @@ class BaseGrammar:
             msg = 'OUT'
             symbol = ''
 
-        parse_match_logging(
-            self.__class__.__name__, '_match', msg,
-            parse_context=parse_context, v_level=self.v_level, dt=dt, m=m, symbol=symbol)
+        # If we can avoid this, bank the performance increase.
+        if parse_context.verbosity > 1:
+            parse_match_logging(
+                self.__class__.__name__, '_match', msg,
+                parse_context=parse_context, v_level=self.v_level, dt=dt, m=m, symbol=symbol)
 
-        # Basic Validation
-        check_still_complete(segments, m.matched_segments, m.unmatched_segments)
+        # Basic Validation, skipped here because it still happens in the parse commands.
+        # check_still_complete(segments, m.matched_segments, m.unmatched_segments)
         return m
 
     def expected_string(self, dialect=None, called_from=None):

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -31,6 +31,10 @@ def verbosity_logger(msg, verbosity=0, level='info', v_level=3):
 
 def parse_match_logging(grammar, func, msg, parse_context, v_level, **kwargs):
     """Log in a particular consistent format for use while matching."""
+    # If we can avoid this, bank the performance increase
+    if parse_context.verbosity <= 1:
+        return
+    # Otherwise carry on...
     symbol = kwargs.pop('symbol', '')
     s = "[PD:{0} MD:{1}]\t{2:<50}\t{3:<20}\t{4:<4}".format(
         parse_context.parse_depth, parse_context.match_depth,
@@ -595,8 +599,9 @@ class BaseSegment:
         parse_match_logging(
             cls.__name__[:10], '_match', 'OUT',
             parse_context=parse_context, v_level=4, m=m)
-        # Basic Validation
-        check_still_complete(segments, m.matched_segments, m.unmatched_segments)
+        # Validation is skipped at a match level. For performance reasons
+        # we match at the parse level only
+        # check_still_complete(segments, m.matched_segments, m.unmatched_segments)
         return m
 
     @staticmethod

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -100,6 +100,10 @@ class ParseBlacklist:
         else:
             self._blacklist_struct[seg_name] = {seg_tuple}
 
+    def clear(self):
+        """Clear the blacklist struct."""
+        self._blacklist_struct = {}
+
 
 class ParseContext:
     """The context for parsing. It holds configuration and rough state.
@@ -343,6 +347,10 @@ class BaseSegment:
         if not parse_context.dialect:
             raise RuntimeError("No dialect provided to {0!r}!".format(self))
 
+        # Clear the blacklist cache so avoid missteps
+        if parse_context:
+            parse_context.blacklist.clear()
+
         # the parse_depth and recurse kwargs control how deep we will recurse for testing.
         if not self.segments:
             # This means we're a root segment, just return an unmutated self
@@ -505,12 +513,14 @@ class BaseSegment:
         # works for both base and raw
         code_only = kwargs.get('code_only', False)
         show_raw = kwargs.get('show_raw', False)
+
         if show_raw and not self.segments:
-            return (self.type, self.raw)
+            result = (self.type, self.raw)
         elif code_only:
-            return (self.type, tuple(seg.to_tuple(**kwargs) for seg in self.segments if seg.is_code and not seg.is_meta))
+            result = (self.type, tuple(seg.to_tuple(**kwargs) for seg in self.segments if seg.is_code and not seg.is_meta))
         else:
-            return (self.type, tuple(seg.to_tuple(**kwargs) for seg in self.segments if not seg.is_meta))
+            result = (self.type, tuple(seg.to_tuple(**kwargs) for seg in self.segments if not seg.is_meta))
+        return result
 
     def to_yaml(self, **kwargs):
         """Return a yaml structure from this segment."""

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -4,6 +4,7 @@ import configparser
 import tempfile
 import os
 import shutil
+import subprocess
 
 # Testing libraries
 import pytest
@@ -210,3 +211,9 @@ def test__cli__command__fix_no_force(rule, fname, prompt, exit_code):
         generic_roundtrip_test(
             test_file, rule, force=False, final_exit_code=exit_code,
             fix_input=prompt)
+
+
+def test___main___help():
+    """Test that the CLI can be access via __main__."""
+    # nonzero exit is good enough
+    subprocess.check_output(['python', '-m', 'sqlfluff', '--help'])

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -84,7 +84,8 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
          "CAST(num AS numeric(8,4))"),
         # Wildcard field selection
         ("SelectTargetElementSegment", "a.*"),
-        ("SelectTargetElementSegment", "a.b.*")
+        ("SelectTargetElementSegment", "a.b.*"),
+        ("SelectTargetElementSegment", "a.b.c.*"),
     ]
 )
 def test__dialect__ansi_specific_segment_parses(segmentref, raw, caplog):

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -81,7 +81,10 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
          "CAST(num AS INT64)"),
         # Casting as datatype with arguments
         ("SelectTargetElementSegment",
-         "CAST(num AS numeric(8,4))")
+         "CAST(num AS numeric(8,4))"),
+        # Wildcard field selection
+        ("SelectTargetElementSegment", "a.*"),
+        ("SelectTargetElementSegment", "a.b.*")
     ]
 )
 def test__dialect__ansi_specific_segment_parses(segmentref, raw, caplog):


### PR DESCRIPTION
So that fluff can be accessed via `python -m sqlfluff`. This is useful if you want to be explicit about the python installation that you want to run fluff on.