### PR TITLE
Add __main__ interface to the cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ env
 .tox
 venv
 .venv 
+.python-version
 
 # Ignore coverage reports
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- For the `parse` command the `--profiler` option to help debugging
+  performance issues.
+
+### Changed
+
+- Validation of the match results of grammars has been reduced. In
+  production cases the validation will still be done, but only on
+  *parse* and not on *match*.
+- At low verbosities, python level logging is also reduced.
+
 ## [0.3.1] - 2020-02-17
 
 ### Added

--- a/src/sqlfluff/__main__.py
+++ b/src/sqlfluff/__main__.py
@@ -1,0 +1,5 @@
+"""Export cli to __main__ for use like python -m sqfluff."""
+from .cli.commands import cli
+
+if __name__ == "__main__":
+    cli()

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -1,6 +1,7 @@
 """Contains the CLI."""
 
 import sys
+import json
 
 import click
 # For the profiler
@@ -111,8 +112,11 @@ def rules(**kwargs):
 
 @cli.command()
 @common_options
+@click.option('-f', '--format', 'format', default='human',
+              type=click.Choice(['human', 'json'], case_sensitive=False),
+              help='What format to return the lint result in.')
 @click.argument('paths', nargs=-1)
-def lint(paths, **kwargs):
+def lint(paths, format, **kwargs):
     """Lint SQL files via passing a list of files or using stdin.
 
     PATH is the path to a sql file or directory to lint. This can be either a
@@ -132,12 +136,13 @@ def lint(paths, **kwargs):
 
     """
     c = get_config(**kwargs)
-    lnt = get_linter(c)
+    lnt = get_linter(c, silent=format == 'json')
     verbose = c.get('verbose')
 
     config_string = format_config(lnt, verbose=verbose)
     if len(config_string) > 0:
         lnt.log(config_string)
+
     # add stdin if specified via lone '-'
     if ('-',) == paths:
         result = lnt.lint_string_wrapped(sys.stdin.read(), fname='stdin', verbosity=verbose)
@@ -151,6 +156,10 @@ def lint(paths, **kwargs):
             sys.exit(1)
         # Output the final stats
         lnt.log(format_linting_result_footer(result, verbose=verbose))
+
+    if format == 'json':
+        click.echo(json.dumps(result.as_records()))
+
     sys.exit(result.stats()['exit code'])
 
 

--- a/src/sqlfluff/default_config.cfg
+++ b/src/sqlfluff/default_config.cfg
@@ -12,6 +12,7 @@ recurse = 0
 dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
 dbt_source = {% macro source(source_name, table) %}{{source_name}}_{{table}}{% endmacro %}
 dbt_config = {% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %}
+dbt_var = {% macro var(variable) %}item{% endmacro %}
 
 # Some rules can be configured directly from the config common to other rules.
 [sqlfluff:rules]

--- a/src/sqlfluff/errors.py
+++ b/src/sqlfluff/errors.py
@@ -98,6 +98,7 @@ class SQLBaseError(ValueError):
 
     def get_info_dict(self):
         """Get a dictionary representation of this violation.
+
         Returns:
             A `dictionary` with keys (code, line_no, line_pos, description)
         """

--- a/src/sqlfluff/errors.py
+++ b/src/sqlfluff/errors.py
@@ -96,6 +96,16 @@ class SQLBaseError(ValueError):
         """
         return self.rule_code(), self.line_no(), self.line_pos(), self.desc()
 
+    def get_info_dict(self):
+        """Get a dictionary representation of this violation.
+        Returns:
+            A `dictionary` with keys (code, line_no, line_pos, description)
+        """
+        return dict(zip(
+            ('code', 'line_no', 'line_pos', 'description'),
+            self.get_info_tuple()
+        ))
+
     def ignore_if_in(self, ignore_iterable):
         """Ignore this violation if it matches the iterable."""
         # Type conversion

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -690,5 +690,7 @@ class Linter:
         for fname in self.paths_from_path(path):
             self.log('=== [\u001b[30;1m{0}\u001b[0m] ==='.format(fname))
             config = self.config.make_child_from_path(fname)
-            with open(fname, 'r') as f:
-                yield self.parse_string(f.read(), fname=fname, verbosity=verbosity, recurse=recurse, config=config)
+            # Handle unicode issues gracefully
+            with open(fname, 'r', encoding='utf8', errors='backslashreplace') as target_file:
+                yield self.parse_string(target_file.read(), fname=fname, verbosity=verbosity,
+                                        recurse=recurse, config=config)

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -386,6 +386,20 @@ class LintingResult:
         all_stats['status'] = 'FAIL' if all_stats['violations'] > 0 else 'PASS'
         return all_stats
 
+    def as_records(self):
+        """Return the result as a list of dictionaries.
+
+        Each record contains a key specifying the filepath, and a list of violations. This
+        method is useful for serialization as all objects will be builtin python types
+        (ints, strs).
+        """
+        return [
+            {'filepath': path, 'violations': [v.get_info_dict() for v in violations]}
+            for lintedpath in self.paths
+            for path, violations in lintedpath.violations().items()
+            if violations
+        ]
+
     def persist_changes(self, verbosity=0, output_func=None, **kwargs):
         """Run all the fixes for all the files and return a dict."""
         return self.combine_dicts(

--- a/src/sqlfluff/parser/grammar.py
+++ b/src/sqlfluff/parser/grammar.py
@@ -422,8 +422,11 @@ class Ref(BaseGrammar):
             raise ValueError("Null Element returned! _elements: {0!r}".format(self._elements))
 
         # First check against the efficiency Cache.
-        # Make a tuple of the incoming segments
-        seg_tuple = BaseSegment.segs_to_tuple(segments, show_raw=True)
+        # We used to use seg_to_tuple here, but it was too slow,
+        # so instead we rely on segments not being mutated within a given
+        # match cycle and so the ids should continue to refer to unchanged
+        # objects.
+        seg_tuple = (id(seg) for seg in segments)
         self_name = self._get_ref()
         if parse_context.blacklist.check(self_name, seg_tuple):
             # This has been tried before.

--- a/src/sqlfluff/parser/grammar.py
+++ b/src/sqlfluff/parser/grammar.py
@@ -68,12 +68,15 @@ class BaseGrammar:
             logging.info("{0}.match, was passed zero length segments list. NB: {0} contains {1!r}".format(
                 self.__class__.__name__, self._elements))
 
-        # Work out the raw representation and curtail if long
-        parse_match_logging(
-            self.__class__.__name__, '_match', 'IN', parse_context=parse_context,
-            v_level=self.v_level,
-            le=len(self._elements), ls=len(segments),
-            seg=join_segments_raw_curtailed(segments))
+        # If we can avoid this, bank the performance increase.
+        if parse_context.verbosity > 1:
+            # Logging to help with debugging.
+            # Work out the raw representation and curtail if long.
+            parse_match_logging(
+                self.__class__.__name__, '_match', 'IN', parse_context=parse_context,
+                v_level=self.v_level,
+                le=len(self._elements), ls=len(segments),
+                seg=join_segments_raw_curtailed(segments))
 
         m = self.match(segments, parse_context=parse_context)
 
@@ -93,12 +96,14 @@ class BaseGrammar:
             msg = 'OUT'
             symbol = ''
 
-        parse_match_logging(
-            self.__class__.__name__, '_match', msg,
-            parse_context=parse_context, v_level=self.v_level, dt=dt, m=m, symbol=symbol)
+        # If we can avoid this, bank the performance increase.
+        if parse_context.verbosity > 1:
+            parse_match_logging(
+                self.__class__.__name__, '_match', msg,
+                parse_context=parse_context, v_level=self.v_level, dt=dt, m=m, symbol=symbol)
 
-        # Basic Validation
-        check_still_complete(segments, m.matched_segments, m.unmatched_segments)
+        # Basic Validation, skipped here because it still happens in the parse commands.
+        # check_still_complete(segments, m.matched_segments, m.unmatched_segments)
         return m
 
     def expected_string(self, dialect=None, called_from=None):

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -31,6 +31,10 @@ def verbosity_logger(msg, verbosity=0, level='info', v_level=3):
 
 def parse_match_logging(grammar, func, msg, parse_context, v_level, **kwargs):
     """Log in a particular consistent format for use while matching."""
+    # If we can avoid this, bank the performance increase
+    if parse_context.verbosity <= 1:
+        return
+    # Otherwise carry on...
     symbol = kwargs.pop('symbol', '')
     s = "[PD:{0} MD:{1}]\t{2:<50}\t{3:<20}\t{4:<4}".format(
         parse_context.parse_depth, parse_context.match_depth,
@@ -595,8 +599,9 @@ class BaseSegment:
         parse_match_logging(
             cls.__name__[:10], '_match', 'OUT',
             parse_context=parse_context, v_level=4, m=m)
-        # Basic Validation
-        check_still_complete(segments, m.matched_segments, m.unmatched_segments)
+        # Validation is skipped at a match level. For performance reasons
+        # we match at the parse level only
+        # check_still_complete(segments, m.matched_segments, m.unmatched_segments)
         return m
 
     @staticmethod

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -100,6 +100,10 @@ class ParseBlacklist:
         else:
             self._blacklist_struct[seg_name] = {seg_tuple}
 
+    def clear(self):
+        """Clear the blacklist struct."""
+        self._blacklist_struct = {}
+
 
 class ParseContext:
     """The context for parsing. It holds configuration and rough state.
@@ -343,6 +347,10 @@ class BaseSegment:
         if not parse_context.dialect:
             raise RuntimeError("No dialect provided to {0!r}!".format(self))
 
+        # Clear the blacklist cache so avoid missteps
+        if parse_context:
+            parse_context.blacklist.clear()
+
         # the parse_depth and recurse kwargs control how deep we will recurse for testing.
         if not self.segments:
             # This means we're a root segment, just return an unmutated self
@@ -505,12 +513,14 @@ class BaseSegment:
         # works for both base and raw
         code_only = kwargs.get('code_only', False)
         show_raw = kwargs.get('show_raw', False)
+
         if show_raw and not self.segments:
-            return (self.type, self.raw)
+            result = (self.type, self.raw)
         elif code_only:
-            return (self.type, tuple(seg.to_tuple(**kwargs) for seg in self.segments if seg.is_code and not seg.is_meta))
+            result = (self.type, tuple(seg.to_tuple(**kwargs) for seg in self.segments if seg.is_code and not seg.is_meta))
         else:
-            return (self.type, tuple(seg.to_tuple(**kwargs) for seg in self.segments if not seg.is_meta))
+            result = (self.type, tuple(seg.to_tuple(**kwargs) for seg in self.segments if not seg.is_meta))
+        return result
 
     def to_yaml(self, **kwargs):
         """Return a yaml structure from this segment."""

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -5,6 +5,7 @@ import tempfile
 import os
 import shutil
 import json
+import subprocess
 
 # Testing libraries
 import pytest
@@ -252,3 +253,9 @@ def test__cli__command_lint_json_multiple_files():
     )
     result = json.loads(result.output)
     assert len(result) == 2
+
+
+def test___main___help():
+    """Test that the CLI can be access via __main__."""
+    # nonzero exit is good enough
+    subprocess.check_output(['python', '-m', 'sqlfluff', '--help'])

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -4,6 +4,7 @@ import configparser
 import tempfile
 import os
 import shutil
+import json
 
 # Testing libraries
 import pytest
@@ -210,3 +211,44 @@ def test__cli__command__fix_no_force(rule, fname, prompt, exit_code):
         generic_roundtrip_test(
             test_file, rule, force=False, final_exit_code=exit_code,
             fix_input=prompt)
+
+
+@pytest.mark.parametrize('sql,expected,exit_code', [
+    ('select * from tbl', [], 0),  # empty list if no violations
+    (
+        'SElect * from tbl',
+        [{
+            "filepath": "stdin",
+            "violations": [
+                {
+                    "code": "L010",
+                    "line_no": 1,
+                    "line_pos": 1,
+                    "description": "Inconsistent capitalisation of keywords."
+                }
+            ]
+        }],
+        65
+    )
+])
+def test__cli__command_lint_json_from_stdin(sql, expected, exit_code):
+    """Check an explicit JSON return value for a single error."""
+    result = invoke_assert_code(
+        args=[lint, ('-', '--rules', 'L010', '--format', 'json')],
+        cli_input=sql,
+        ret_code=exit_code
+    )
+    assert json.loads(result.output) == expected
+
+
+def test__cli__command_lint_json_multiple_files():
+    """Check the general format of JSON output for multiple files."""
+    fpath = 'test/fixtures/linter/indentation_errors.sql'
+
+    # note the file is in here twice. two files = two payloads.
+    result = invoke_assert_code(
+        args=[lint, (fpath, fpath, '--format', 'json')],
+        ret_code=65,
+    )
+    result = json.loads(result.output)
+    assert len(result) == 2


### PR DESCRIPTION
So that you can access the fluff CLI via `python -m sqlfluff`. This is very useful when you want to be specific about what python installation you're running!