### PR TITLE
Add __main__ interface to the cli

### DIFF
--- a/src/sqlfluff/__main__.py
+++ b/src/sqlfluff/__main__.py
@@ -1,0 +1,5 @@
+"""Export cli to __main__ for use like python -m sqfluff."""
+from .cli.commands import cli
+
+if __name__ == "__main__":
+    cli()

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -5,6 +5,7 @@ import tempfile
 import os
 import shutil
 import json
+import subprocess
 
 # Testing libraries
 import pytest
@@ -252,3 +253,9 @@ def test__cli__command_lint_json_multiple_files():
     )
     result = json.loads(result.output)
     assert len(result) == 2
+
+
+def test___main___help():
+    """Test that the CLI can be access via __main__."""
+    # nonzero exit is good enough
+    subprocess.check_output(['python', '-m', 'sqlfluff', '--help'])


### PR DESCRIPTION
So that you can access the fluff CLI via `python -m sqlfluff`. This is very useful when you want to be specific about what python installation you're running!