### PR TITLE
Allow escaped quotes and raw/regex strings in BigQuery dialect.

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -14,9 +14,9 @@ from .dialect_ansi import ansi_dialect
 bigquery_dialect = ansi_dialect.copy_as('bigquery')
 
 bigquery_dialect.patch_lexer_struct([
-    # Quoted literals can have r or b (case insensitive) prefixes, in any order, to 
+    # Quoted literals can have r or b (case insensitive) prefixes, in any order, to
     # indicate a raw/regex string or byte sequence, respectively.  Allow escaped quote
-    # characters inside strings by allowing \" with an optional even multiple of 
+    # characters inside strings by allowing \" with an optional even multiple of
     # backslashes in front of it.
     ("single_quote", "regex", r"([rR]?[bB]?|[bB]?[rR]?)?'((?<!\\)(\\{2})*\\'|[^'])*(?<!\\)(\\{2})*'", dict(is_code=True)),
     ("double_quote", "regex", r'([rR]?[bB]?|[bB]?[rR]?)?"((?<!\\)(\\{2})*\\"|[^"])*(?<!\\)(\\{2})*"', dict(is_code=True))

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -14,9 +14,10 @@ from .dialect_ansi import ansi_dialect
 bigquery_dialect = ansi_dialect.copy_as('bigquery')
 
 bigquery_dialect.patch_lexer_struct([
-    # Quoted literals can have r or b (case insensitive) prefixes, in any order, to indicate a
-    # raw/regex string or byte sequence, respectively.  Allow escaped quote characters inside
-    # strings by allowing \" with an optional even multiple of backslashes in front of it.
+    # Quoted literals can have r or b (case insensitive) prefixes, in any order, to 
+    # indicate a raw/regex string or byte sequence, respectively.  Allow escaped quote
+    # characters inside strings by allowing \" with an optional even multiple of 
+    # backslashes in front of it.
     ("single_quote", "regex", r"([rR]?[bB]?|[bB]?[rR]?)?'((?<!\\)(\\{2})*\\'|[^'])*(?<!\\)(\\{2})*'", dict(is_code=True)),
     ("double_quote", "regex", r'([rR]?[bB]?|[bB]?[rR]?)?"((?<!\\)(\\{2})*\\"|[^"])*(?<!\\)(\\{2})*"', dict(is_code=True))
 ])

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -2,6 +2,8 @@
 
 This inherits from the ansi dialect, with changes as specified by
 https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax
+and
+https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
 """
 
 from ..parser import (NamedSegment, OneOf, Ref)
@@ -10,6 +12,14 @@ from .dialect_ansi import ansi_dialect
 
 
 bigquery_dialect = ansi_dialect.copy_as('bigquery')
+
+bigquery_dialect.patch_lexer_struct([
+    # Quoted literals can have r or b (case insensitive) prefixes, in any order, to indicate a
+    # raw/regex string or byte sequence, respectively.  Allow escaped quote characters inside
+    # strings by allowing \" with an optional even multiple of backslashes in front of it.
+    ("single_quote", "regex", r"([rR]?[bB]?|[bB]?[rR]?)?'((?<!\\)(\\{2})*\\'|[^'])*(?<!\\)(\\{2})*'", dict(is_code=True)),
+    ("double_quote", "regex", r'([rR]?[bB]?|[bB]?[rR]?)?"((?<!\\)(\\{2})*\\"|[^"])*(?<!\\)(\\{2})*"', dict(is_code=True))
+])
 
 bigquery_dialect.add(
     DoubleQuotedLiteralSegment=NamedSegment.make('double_quote', name='literal', type='quoted_literal')

--- a/test/fixtures/parser/bigquery/string_literals.sql
+++ b/test/fixtures/parser/bigquery/string_literals.sql
@@ -1,0 +1,28 @@
+-- Examples from https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
+SELECT
+    "",
+    '',
+    "abc",
+    "it's",
+    'it\'s',
+    'Title: "Boy"',
+    "test \"escaped\"",
+    'test \'escaped\'',
+    "test \\\"escaped",
+    "test \"escaped\\\"",
+    r"",
+    r'',
+    r"abc+",
+    R"abc+",
+    r'abc+',
+    R'abc+',
+    r'f\(abc, (.*),def\)',
+    r"f\(abc, (.*),def\)",
+    b'abc',
+    B"abc",
+    rb"abc*",
+    rB"abc*",
+    Rb'abc*',
+    br'abc+',
+    RB"abc+"
+FROM dummy


### PR DESCRIPTION
We had some instances of raw strings in a dbt project using bigquery that I'm working on adding sqlfluff to.

This change should parse everything listed under "Quoted string" and "Raw string" from the "String and Bytes Literals" section of BQ's SQL ref: (https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals).

Adding a query to the fixtures seemed the easiest way to test a bunch of instances.  I had also thought about adding a `dialects_bigquery_test.py` to and duplicating the chunk that tests specific segment parsing - do you have a particular preference here?