### PR TITLE
Allow value of INTERVAL to be a function in BigQuery.

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -214,7 +214,6 @@ ansi_dialect.add(
     LiteralGrammar=OneOf(
         Ref('QuotedLiteralSegment'), Ref('NumericLiteralSegment'),
         Ref('BooleanLiteralGrammar'), Ref('QualifiedNumericLiteralSegment'),
-        Ref('IntervalLiteralSegment'),
         # NB: Null is included in the literals, because it is a keyword which
         # can otherwise be easily mistaken for an identifier.
         Ref('NullKeywordSegment')
@@ -223,9 +222,9 @@ ansi_dialect.add(
 
 
 @ansi_dialect.segment()
-class IntervalLiteralSegment(BaseSegment):
-    """An interval literal segment."""
-    type = 'interval_literal'
+class IntervalExpressionSegment(BaseSegment):
+    """An interval expression segment."""
+    type = 'interval_expression'
     match_grammar = Sequence(
         Ref('IntervalKeywordSegment'),
         OneOf(
@@ -532,6 +531,7 @@ class SelectTargetElementSegment(BaseSegment):
             OneOf(
                 Ref('LiteralGrammar'),
                 Ref('FunctionSegment'),
+                Ref('IntervalExpressionSegment'),
                 Ref('ObjectReferenceSegment')
             ),
             Ref('AliasExpressionSegment', optional=True)
@@ -751,6 +751,7 @@ ansi_dialect.add(
                         OneOf(
                             Delimited(
                                 Ref('LiteralGrammar'),
+                                Ref('IntervalExpressionSegment'),
                                 delimiter=Ref('CommaSegment')
                             ),
                             Ref('SelectStatementSegment')
@@ -801,6 +802,7 @@ ansi_dialect.add(
             # Allow potential select statement without brackets
             Ref('SelectStatementSegment'),
             Ref('LiteralGrammar'),
+            Ref('IntervalExpressionSegment'),
             Ref('ObjectReferenceSegment')
         ),
         AnyNumberOf(
@@ -1020,6 +1022,7 @@ class ValuesClauseSegment(BaseSegment):
             Bracketed(
                 Delimited(
                     Ref('LiteralGrammar'),
+                    Ref('IntervalExpressionSegment'),
                     delimiter=Ref('CommaSegment')
                 )
             ),
@@ -1187,6 +1190,7 @@ class ColumnOptionSegment(BaseSegment):
             Sequence(  # DEFAULT <value>
                 Ref('DefaultKeywordSegment'),
                 Ref('LiteralGrammar'),
+                # ?? Ref('IntervalExpressionSegment')
             ),
             Sequence(  # PRIMARY KEY
                 Ref('PrimaryKeywordSegment'),

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -6,7 +6,7 @@ and
 https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
 """
 
-from ..parser import (NamedSegment, OneOf, Ref)
+from ..parser import (BaseSegment, NamedSegment, OneOf, Ref, Sequence)
 
 from .dialect_ansi import ansi_dialect
 
@@ -26,10 +26,29 @@ bigquery_dialect.add(
     DoubleQuotedLiteralSegment=NamedSegment.make('double_quote', name='literal', type='quoted_literal')
 )
 
+
+# BigQuery allows functions in INTERVAL
+class IntervalExpressionSegment(BaseSegment):
+    """An interval with a function as value segment."""
+    type = 'interval_expression'
+    match_grammar = Sequence(
+        Ref('IntervalKeywordSegment'),
+        OneOf(
+            Ref('NumericLiteralSegment'),
+            Ref('FunctionSegment')
+        ),
+        OneOf(
+            Ref('QuotedLiteralSegment'),
+            Ref('DatepartSegment')
+        )
+    )
+
+
 bigquery_dialect.replace(
     QuotedIdentifierSegment=NamedSegment.make('back_quote', name='identifier', type='quoted_identifier'),
+    IntervalExpressionSegment=IntervalExpressionSegment,
     LiteralGrammar=OneOf(
         Ref('QuotedLiteralSegment'), Ref('DoubleQuotedLiteralSegment'), Ref('NumericLiteralSegment'),
-        Ref('BooleanLiteralGrammar'), Ref('QualifiedNumericLiteralSegment'), Ref('IntervalLiteralSegment')
+        Ref('BooleanLiteralGrammar'), Ref('QualifiedNumericLiteralSegment')
     ),
 )

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -34,7 +34,7 @@ def test__dialect__ansi__file_from_raw(raw, res, caplog):
         ("NakedIdentifierSegment", "online_sales"),
         ("NumericLiteralSegment", "1000.0"),
         ("ExpressionSegment", "online_sales / 1000.0"),
-        ("IntervalLiteralSegment", "INTERVAL 1 YEAR"),
+        ("IntervalExpressionSegment", "INTERVAL 1 YEAR"),
         ("ExpressionSegment",
          "CASE WHEN id = 1 THEN 'nothing' ELSE 'test' END"),
         # Nested Case Expressions

--- a/test/fixtures/parser/bigquery/interval_function.sql
+++ b/test/fixtures/parser/bigquery/interval_function.sql
@@ -1,0 +1,5 @@
+SELECT
+    TIMESTAMP_TRUNC(TIMESTAMP_ADD(session_start.eventTimestamp, INTERVAL cast(TIMESTAMP_DIFF(session_end.eventTimestamp, session_start.eventTimestamp, SECOND)/2 AS int64) second), HOUR) AS avgAtHour,
+    TIME_ADD(time1, INTERVAL 10 MINUTE) AS after,
+    DATE_SUB(time2, INTERVAL 5 YEAR) AS before
+FROM dummy;


### PR DESCRIPTION
This is a change I made locally to support our dbt bq project where we have an interval specified with a cast and a call to timestamp_diff.  I believe this is bigquery-only but I'm not sure.

I'm slightly uncomfortable with putting something including a function call into `LiteralGrammar`.

@alanmcruickshank do you think this is something you're interested in?