### PR TITLE
Add missing requirements to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,10 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
     install_requires=[
+        'bench-it',
         'click>=2.0',
         "colorama>=0.3",
+        'configparser',
         'oyaml',
         'Jinja2',
         "diff-cover>=2.5.0,<3.0",


### PR DESCRIPTION
Noticed these were present in `requirements.txt` but not in `setup.py`.  I'm pulling in a forked version of sqlfluff from git directly and it gets dependencies to install from here.