### PR TITLE
Fix install bug on MacOS

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md LICENSE.md CHANGELOG.md
+include src/sqlfluff/config.ini
+include src/sqlfluff/default_config.cfg

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
     install_requires=[
+        'bench-it',
         'click>=2.0',
         "colorama>=0.3",
         'oyaml',

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,4 @@ setup(
             'sqlfluff = sqlfluff.diff_quality_plugin'
         ],
     },
-    # Use datafiles to make sure the config versioning file is included
-    data_files=[('', ['src/sqlfluff/config.ini', 'README.md', 'CHANGELOG.md', 'src/sqlfluff/default_config.cfg'])]
 )


### PR DESCRIPTION
## Summary

This PR is designed to fix an issue raised in #211 whereby an install attempted without using a `virtualenv` on macOS Mojave and Catalina would fail. 

This PR is adapted from https://github.com/alanmcruickshank/sqlfluff/pull/216 where @alanmcruickshank has been working on a fix for this issue.

It turns out the `data_files` parameter in `setup.py` was attempting to place files in `/usr/local` by default, which gave a `Permission Denied` error.

[This StackOverflow post](https://stackoverflow.com/questions/43800753/pip-tries-to-install-package-in-the-wrong-location) suggested that using a `MANIFEST.in` file in tandem with setting `include_package_data=True` would ensure that any files listed in the manifest file were included in the distribution as expected. I tried that, and it worked.

Additionally, I've included `bench-it` in the `install_requires list, since it is needed to `pip install` the package but was missing (I believe I did this right).

## Why I think this works

`tox` succeeds.

I am able to `pip install .` from the `sqlfluff` directory with no errors.

`sqlfluff` runs as expected:

```
• ~/src/sqlfluff $ echo "  SELECT a  +  b FROM tbl;  " > test.sql
• ~/src/sqlfluff $ sqlfluff lint test.sql
== [test.sql] FAIL
L:   1 | P:   3 | L003 | First line has unexpected indent
L:   1 | P:  11 | L006 | Operators should be preceded by a space.
L:   1 | P:  14 | L006 | Operators should be followed by a space.
L:   1 | P:  27 | L001 | Uneccessary trailing whitespace.
```

I can confirm the files listed in `MANIFEST.in` are included in the `sdist`: 

```
• ~/src/sqlfluff $ tar -ztvf dist/sqlfluff-0.3.1.tar.gz
drwxr-xr-x  0 ryan.tuck staff       0 Apr  7 17:51 sqlfluff-0.3.1/
-rw-r--r--  0 ryan.tuck staff   14143 Apr  7 17:33 sqlfluff-0.3.1/CHANGELOG.md
-rw-r--r--  0 ryan.tuck staff    1073 Apr  7 17:33 sqlfluff-0.3.1/LICENSE.md
-rw-r--r--  0 ryan.tuck staff     114 Apr  7 17:33 sqlfluff-0.3.1/MANIFEST.in
-rw-r--r--  0 ryan.tuck staff   22030 Apr  7 17:51 sqlfluff-0.3.1/PKG-INFO
-rw-r--r--  0 ryan.tuck staff    3473 Apr  7 17:33 sqlfluff-0.3.1/README.md
-rw-r--r--  0 ryan.tuck staff      38 Apr  7 17:51 sqlfluff-0.3.1/setup.cfg
-rw-r--r--  0 ryan.tuck staff    3056 Apr  7 17:37 sqlfluff-0.3.1/setup.py
drwxr-xr-x  0 ryan.tuck staff       0 Apr  7 17:51 sqlfluff-0.3.1/src/
drwxr-xr-x  0 ryan.tuck staff       0 Apr  7 17:51 sqlfluff-0.3.1/src/sqlfluff/
-rw-r--r--  0 ryan.tuck staff     279 Apr  7 17:33 sqlfluff-0.3.1/src/sqlfluff/__init__.py
...
```

@alanmcruickshank - please feel free to simply copy the small changeset of this PR in your existing PR #216 if that's easiest, or let me know if anything else is needed!