### PR TITLE
Comment out debugging output

### DIFF
--- a/src/sqlfluff/parser/lexer.py
+++ b/src/sqlfluff/parser/lexer.py
@@ -307,7 +307,7 @@ class Lexer:
             res = self.matcher.match(raw, start_pos)
             segment_buff += res.segments
             if len(res.new_string) > 0:
-                print(repr(res.new_string))
+                #print(repr(res.new_string))
                 violations.append(SQLLexError(
                     "Unable to lex characters: '{0!r}...'".format(
                         res.new_string[:10]),
@@ -319,7 +319,7 @@ class Lexer:
                 if not resort_res:
                     # If we STILL can't match, then just panic out.
                     raise violations[-1]
-                print(resort_res)
+                #print(resort_res)
 
                 raw = resort_res.new_string
                 start_pos = resort_res.new_pos

--- a/src/sqlfluff/parser/lexer.py
+++ b/src/sqlfluff/parser/lexer.py
@@ -307,7 +307,7 @@ class Lexer:
             res = self.matcher.match(raw, start_pos)
             segment_buff += res.segments
             if len(res.new_string) > 0:
-                #print(repr(res.new_string))
+                # print(repr(res.new_string))
                 violations.append(SQLLexError(
                     "Unable to lex characters: '{0!r}...'".format(
                         res.new_string[:10]),
@@ -319,7 +319,7 @@ class Lexer:
                 if not resort_res:
                     # If we STILL can't match, then just panic out.
                     raise violations[-1]
-                #print(resort_res)
+                # print(resort_res)
 
                 raw = resort_res.new_string
                 start_pos = resort_res.new_pos


### PR DESCRIPTION
This PR addresses #233. I commented out the debugging-related `print()` calls. I'd be happy to remove them instead, if you prefer.