### PR TITLE
Bugfix + More performance improvements

### DIFF
--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -221,8 +221,19 @@ class BaseSegment:
 
     @classmethod
     def simple(cls, parse_context):
-        """Does this matcher support an uppercase hash matching route?"""
-        return False
+        """Does this matcher support an uppercase hash matching route?
+
+        This should be true if the MATCH grammar is simple. Most more
+        complicated segments will be assumed to overwrite this method
+        if they wish to be considered simple.
+        """
+        match_grammar = cls._match_grammar()
+        if match_grammar:
+            return match_grammar.simple(parse_context=parse_context)
+        else:
+            # Other segments will either override this method, or aren't
+            # simple.
+            return False
 
     @property
     def is_code(self):

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -1548,6 +1548,8 @@ class Rule_L017(BaseCrawler):
 class Rule_L018(BaseCrawler):
     """WITH clause closing bracket should be aligned with WITH keyword."""
 
+    _works_on_unparsable = False
+
     def __init__(self, tab_space_size=4, **kwargs):
         """Initialise, extracting the tab size from the config.
 
@@ -1572,6 +1574,12 @@ class Rule_L018(BaseCrawler):
                 else:
                     raw_stack_buff.append(seg)
             else:
+                # This *could* happen if the with statement is unparsable,
+                # in which case then the user will have to fix that first.
+                if any(s.type == 'unparsable' for s in segment.segments):
+                    return LintResult()
+                # If it's parsable but we still didn't find a with, then
+                # we should raise that.
                 raise RuntimeError("Didn't find WITH keyword!")
 
             def indent_size_up_to(segs):


### PR DESCRIPTION
Fixes a bug with `unparsable` `WITH` clauses and rule L018.

Another low hanging performance improvement fruit. `BaseSegment` now claims to be simple if it has a match grammar, and that grammar is also simple. This provides a meaningful -25% speed increase on very long queries (1000+ lines).

Fixes #189 (for now)