### PR TITLE
Add WITHIN GROUP syntax and stability to BaseSegment

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -351,8 +351,35 @@ ansi_dialect.add(
                 ),
             ),
         )
-    )
+    ),
+    # Optional OVER suffix for window functions.
+    # This is supported in biquery & postgres (and it's derivatives)
+    # and so is included here for now.
+    PostFunctionGrammar=Ref('OverClauseSegment')
 )
+
+
+@ansi_dialect.segment()
+class OverClauseSegment(BaseSegment):
+    """An OVER clause for window functions."""
+    type = 'over_clause'
+    match_grammar = Sequence(
+        'OVER',
+        Bracketed(
+            Anything(optional=True)
+        ),
+    )
+
+    parse_grammar = Sequence(
+        'OVER',
+        Bracketed(
+            Sequence(
+                Ref('PartitionClauseSegment', optional=True),
+                Ref('OrderByClauseSegment', optional=True),
+                Ref('FrameClauseSegment', optional=True)
+            )
+        ),
+    )
 
 
 @ansi_dialect.segment()
@@ -372,14 +399,9 @@ class FunctionSegment(BaseSegment):
                 Anything(optional=True)
             ),
         ),
-        Sequence(
-            'OVER',
-            Bracketed(
-                Anything(optional=True)
-            ),
-            optional=True
-        )
+        Ref('PostFunctionGrammar', optional=True)
     )
+
     parse_grammar = Sequence(
         Sequence(
             Ref('FunctionNameSegment'),
@@ -390,19 +412,7 @@ class FunctionSegment(BaseSegment):
                     optional=True)
             ),
         ),
-        # Optional suffix for window functions.
-        # TODO: Should this be in a different dialect?
-        Sequence(
-            'OVER',
-            Bracketed(
-                Sequence(
-                    Ref('PartitionClauseSegment', optional=True),
-                    Ref('OrderByClauseSegment', optional=True),
-                    Ref('FrameClauseSegment', optional=True)
-                )
-            ),
-            optional=True
-        )
+        Ref('PostFunctionGrammar', optional=True)
     )
 
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -22,7 +22,10 @@ postgres_dialect.sets('reserved_keywords').add('WITHIN')
 
 @postgres_dialect.segment()
 class WithinGroupClauseSegment(BaseSegment):
-    """An WITHIN GROUP clause for window functions."""
+    """An WITHIN GROUP clause for window functions.
+
+    https://www.postgresql.org/docs/current/functions-aggregate.html.
+    """
     type = 'withingroup_clause'
     match_grammar = Sequence(
         'WITHIN', 'GROUP',

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1,6 +1,41 @@
 """The PostgreSQL dialect."""
 
+from ..parser import (OneOf, Ref, Sequence, Bracketed, Anything, BaseSegment)
+
 from .dialect_ansi import ansi_dialect
 
 # At the moment this is just a placeholder. Unique syntax to be added later.
 postgres_dialect = ansi_dialect.copy_as('postgres')
+
+postgres_dialect.replace(
+    PostFunctionGrammar=OneOf(
+        Ref('OverClauseSegment'),
+        Ref('WithinGroupClauseSegment')
+    )
+)
+
+
+# Reserve WITHIN (required for the WithinGroupClauseSegment)
+postgres_dialect.sets('unreserved_keywords').remove('WITHIN')
+postgres_dialect.sets('reserved_keywords').add('WITHIN')
+
+
+@postgres_dialect.segment()
+class WithinGroupClauseSegment(BaseSegment):
+    """An WITHIN GROUP clause for window functions."""
+    type = 'withingroup_clause'
+    match_grammar = Sequence(
+        'WITHIN', 'GROUP',
+        Bracketed(
+            Anything(optional=True)
+        ),
+    )
+
+    parse_grammar = Sequence(
+        'WITHIN', 'GROUP',
+        Bracketed(
+            Sequence(
+                Ref('OrderByClauseSegment', optional=True)
+            )
+        ),
+    )

--- a/src/sqlfluff/parser/grammar.py
+++ b/src/sqlfluff/parser/grammar.py
@@ -724,7 +724,12 @@ class OneOf(BaseGrammar):
         # For efficiency, we'll be pruning options if we can
         # based on their simpleness. this provides a short cut
         # to return earlier if we can.
-        str_buff = [s.raw_upper for s in segments]
+        # `segments` may already be nested so we need to break out
+        # the raw segments within it.
+        str_buff = []
+        for upper_segment in segments:
+            for inner_segment in upper_segment.iter_raw_seg():
+                str_buff.append(inner_segment.raw_upper)
         available_options = []
         prune_buff = []
         for opt in self._elements:

--- a/test/fixtures/parser/postgres/postgres_within_group.sql
+++ b/test/fixtures/parser/postgres/postgres_within_group.sql
@@ -1,0 +1,3 @@
+-- Postgres style WITHIN GROUP window functions
+SELECT ARRAY_AGG(o_orderkey) WITHIN GROUP (ORDER BY o_orderkey ASC)
+FROM orders


### PR DESCRIPTION
This fixes #293 .

NB: Relies on #265 being merged first to look less bloated.

Also includes some stability for BaseSegment to catch a few edge cases that occur with deep matching and parsing.