### PR TITLE
Fixes #323: Fix from stdin writes more than the fixed sql to stdout

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -205,7 +205,7 @@ def fix(force, paths, **kwargs):
     be interpreted like passing the current working directory as a path argument.
     """
     c = get_config(**kwargs)
-    lnt = get_linter(c)
+    lnt = get_linter(c, silent=('-',) == paths)
     verbose = c.get('verbose')
 
     config_string = format_config(lnt, verbose=verbose)
@@ -221,7 +221,7 @@ def fix(force, paths, **kwargs):
     if ('-',) == paths:
         stdin = sys.stdin.read()
         result = lnt.lint_string_wrapped(stdin, fname='stdin', verbosity=verbose, fix=True)
-        stdout = result.paths[0].files[0].fix_string(verbosity=verbose)
+        stdout = result.paths[0].files[0].fix_string(verbosity=verbose)[0]
         click.echo(stdout, nl=False)
         sys.exit()
 

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -199,17 +199,14 @@ def test__cli__command__fix(rule, fname):
 #         generic_roundtrip_test(test_file, rule, fix_exit_code=1, final_exit_code=65)
 
 
-def test__cli__command_fix_stdin(monkeypatch):
+@pytest.mark.parametrize('stdin,rules,stdout', [
+    ('select * from t', 'L003', 'select * from t'),  # no change
+    (' select * from t', 'L003', 'select * from t'),  # fix preceding whitespace
+])
+def test__cli__command_fix_stdin(stdin, rules, stdout):
     """Check stdin input for fix works."""
-    sql = 'select * from tbl'
-    expected = 'fixed sql!'
-
-    def _patched_fix(self, verbosity=0):
-        return expected
-
-    monkeypatch.setattr("sqlfluff.linter.LintedFile.fix_string", _patched_fix)
-    result = invoke_assert_code(args=[fix, ('-', '--rules', 'L001')], cli_input=sql)
-    assert result.output == expected
+    result = invoke_assert_code(args=[fix, ('-', '--rules', rules)], cli_input=stdin)
+    assert result.output == stdout
 
 
 @pytest.mark.parametrize('rule,fname,prompt,exit_code', [


### PR DESCRIPTION
A small adjustment to the fix CLI handler for stdin, and remove the monkeypatch on the tests (which is why this was not caught initially).