### PR TITLE
Allow trailing commas in the column list of a SELECT (BigQuery allows this)

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -586,7 +586,8 @@ class SelectClauseSegment(BaseSegment):
         Indent,
         Delimited(
             Ref('SelectTargetElementSegment'),
-            delimiter=Ref('CommaSegment')
+            delimiter=Ref('CommaSegment'),
+            allow_trailing=True
         ),
         Dedent
     )

--- a/test/fixtures/parser/ansi/select_trailing_comma_column_list.sql
+++ b/test/fixtures/parser/ansi/select_trailing_comma_column_list.sql
@@ -1,0 +1,4 @@
+SELECT
+    user_id,
+FROM
+    table

--- a/test/fixtures/parser/ansi/select_where_in_unnest.sql
+++ b/test/fixtures/parser/ansi/select_where_in_unnest.sql
@@ -1,0 +1,6 @@
+SELECT
+    user_id
+FROM
+    t
+WHERE
+    1 IN UNNEST(t.c)

--- a/test/fixtures/parser/ansi/select_where_in_unnest.sql
+++ b/test/fixtures/parser/ansi/select_where_in_unnest.sql
@@ -1,6 +1,0 @@
-SELECT
-    user_id
-FROM
-    t
-WHERE
-    1 IN UNNEST(t.c)


### PR DESCRIPTION
Addresses #340 