### PR TITLE
Add support for `CASE expr` syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -721,6 +721,7 @@ class CaseExpressionSegment(BaseSegment):
     type = 'case_expression'
     match_grammar = Sequence(
         'CASE',
+        Ref('ExpressionSegment', optional=True),
         Indent,
         AnyNumberOf(
             Sequence(

--- a/test/fixtures/parser/bigquery/select_case_expr.sql
+++ b/test/fixtures/parser/bigquery/select_case_expr.sql
@@ -1,0 +1,7 @@
+select
+  case fruit_code
+    when 0 then 'apple'
+    when 1 then 'banana'
+    when 2 then 'cashew'
+  end as fruit
+from some_table


### PR DESCRIPTION
Addresses `test/fixtures/parser/bigquery/select_case.sql` (one of the parsing issues noted in PR #353)

Previously, the ANSI grammar supported `CASE WHEN` but not `CASE expr WHEN`.

@jml