### PR TITLE
Check for column aliases in L027

### DIFF
--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -2479,7 +2479,7 @@ class Rule_L025(Rule_L020):
             tbl_ref = None
         return this_ref_type, tbl_ref
 
-    def _lint_references_and_aliases(self, aliases, references, using_cols, parent_select):
+    def _lint_references_and_aliases(self, aliases, references, col_aliases, using_cols, parent_select):
         """Check all aliased references against tables referenced in the query."""
         # A buffer to keep any violations.
         violation_buff = []
@@ -2525,7 +2525,7 @@ class Rule_L026(Rule_L025):
 
     """
 
-    def _lint_references_and_aliases(self, aliases, references, using_cols, parent_select):
+    def _lint_references_and_aliases(self, aliases, references, col_aliases, using_cols, parent_select):
         # A buffer to keep any violations.
         violation_buff = []
 
@@ -2646,7 +2646,7 @@ class Rule_L028(Rule_L025):
         self.single_table_references = single_table_references
         super().__init__(**kwargs)
 
-    def _lint_references_and_aliases(self, aliases, references, using_cols, parent_select):
+    def _lint_references_and_aliases(self, aliases, references, col_aliases, using_cols, parent_select):
         """Iterate through references and check consistency."""
         # How many aliases are there? If more than one then abort.
         if len(aliases) > 1:

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -2589,7 +2589,7 @@ class Rule_L027(Rule_L025):
                 this_ref_type == 'unqualified'
                 and r.raw not in col_aliases
                 and r.raw not in using_cols
-                ):
+            ):
                 violation_buff.append(
                     LintResult(
                         anchor=r,

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -2175,6 +2175,13 @@ class Rule_L020(BaseCrawler):
                 if any(seg.type == 'select_statement' and seg is not segment for seg in ref_path):
                     reference_buffer.remove(ref)
 
+            # Get all column aliases
+            col_aliases = []
+            for col_seg in list(sc.recursive_crawl('alias_expression')):
+                for seg in col_seg.segments:
+                    if seg.type == "identifier":
+                        col_aliases.append(seg.raw)
+
             # Get any columns referred to in a using clause, and extract anything
             # from ON clauses.
             using_cols = []
@@ -2198,13 +2205,6 @@ class Rule_L020(BaseCrawler):
                     elif seen_on and seg.type == 'expression':
                         # Deal with expressions
                         reference_buffer += list(seg.recursive_crawl('object_reference'))
-
-            # Get all column aliases
-            col_aliases = []
-            for column_segment in list(sc.recursive_crawl('alias_expression')):
-                for segment in column_segment.segments:
-                    if segment.type == "identifier":
-                        col_aliases.append(segment.raw)
 
             # Work out if we have a parent select function
             parent_select = None

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -2576,7 +2576,7 @@ class Rule_L027(Rule_L025):
         LEFT JOIN vee ON vee.a = foo.a
     """
 
-    def _lint_references_and_aliases(self, aliases, references, using_cols, parent_select):
+    def _lint_references_and_aliases(self, aliases, references, col_aliases, using_cols, parent_select):
         # Do we have more than one? If so, all references should be qualified.
         if len(aliases) <= 1:
             return None
@@ -2585,7 +2585,11 @@ class Rule_L027(Rule_L025):
         # Check all the references that we have.
         for r in references:
             this_ref_type, _ = self._extract_type_tbl_reference(r)
-            if this_ref_type == 'unqualified' and r.raw not in using_cols:
+            if (
+                this_ref_type == 'unqualified'
+                and r.raw not in col_aliases
+                and r.raw not in using_cols
+                ):
                 violation_buff.append(
                     LintResult(
                         anchor=r,

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -2117,7 +2117,7 @@ class Rule_L019(BaseCrawler):
 class Rule_L020(BaseCrawler):
     """Table aliases should be unique within each clause."""
 
-    def _lint_references_and_aliases(self, aliases, references, using_cols, parent_select):
+    def _lint_references_and_aliases(self, aliases, references, col_aliases, using_cols, parent_select):
         """Check whether any aliases are duplicates.
 
         NB: Subclasses of this error should override this function.
@@ -2199,6 +2199,13 @@ class Rule_L020(BaseCrawler):
                         # Deal with expressions
                         reference_buffer += list(seg.recursive_crawl('object_reference'))
 
+            # Get all column aliases
+            col_aliases = []
+            for column_segment in list(sc.recursive_crawl('alias_expression')):
+                for segment in column_segment.segments:
+                    if segment.type == "identifier":
+                        col_aliases.append(segment.raw)
+
             # Work out if we have a parent select function
             parent_select = None
             for seg in reversed(parent_stack):
@@ -2208,7 +2215,7 @@ class Rule_L020(BaseCrawler):
 
             # Pass them all to the function that does all the work.
             # NB: Subclasses of this rules should override the function below
-            return self._lint_references_and_aliases(aliases, reference_buffer, using_cols, parent_select)
+            return self._lint_references_and_aliases(aliases, reference_buffer, col_aliases, using_cols, parent_select)
         return None
 
 

--- a/test/fixtures/linter/column_references.sql
+++ b/test/fixtures/linter/column_references.sql
@@ -1,2 +1,2 @@
-select a, b.c, d.g, f
-from z as a JOIN d using(f)
+select a, b.c, d.g, f as f1, f1 + 1 as f2
+from z as a JOIN d using(f) where f2 > 1


### PR DESCRIPTION
Fixes #396 -- I can make a separate issue for improving the config documentation
Fixes #400 

Your docs and code comments are the 💣 I wouldn't have stood a chance of contributing without them. Love the test suite as well (😍 `pytest`) which also helped me figure out how I was going to test my changes. Also, thanks for the guidance in #400 on how to tackle this 🙇‍♂️ 

A few notes:
- VSCode was complaining that several arguments in the various `_lint_references_and_aliases` methods went unused. I'm guessing this was intentional on your part, and so I kept that consistent. If you prefer elsewise, I'm happy to remove the additional parameter from the other methods
- I was getting some weird behavior when I put the alias extraction code in `L020._eval()` _before_ the using cols extraction. To be specific, I was getting `NoneType error: fc has no attribute 'recursive_crawl'`. This went away if I took away the added `where` clause in the test sql file. I though it was really strange because I wasn't trying to mess with the `from` statement parsing, but it seemed to be effected by having the column alias extraction from the select statement before it. Once I moved the  column alias extraction _after_ the using cols extraction, everything worked fine again, even with the extra `where` clause. ~No idea how that was happening, but thought you might want to know in case it illuminates some poor design decision that I made~. After checking the [`DeepSource` CI](https://deepsource.io/gh/alanmcruickshank/sqlfluff/run/dc211f41-3d5e-4fa2-8c7a-68068712b40b/python/PYL-R1704) I now see that the problem is that I was redefining `segment` 🤦‍♂️ I'll fix that
- I also see what you mean with `L020` and it's descendants being a little unruly. I don't have any bright ideas 💡 now, but I'll keep my mind open as I continue to explore + contribute to this project.