### PR TITLE
Add BareFunctionSegment

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -109,6 +109,10 @@ ansi_dialect.add(
     LessThanOrEqualToSegment=KeywordSegment.make('<=', name='less_than_equal_to', type='comparison_operator'),
     NotEqualToSegment_a=KeywordSegment.make('!=', name='not_equal_to', type='comparison_operator'),
     NotEqualToSegment_b=KeywordSegment.make('<>', name='not_equal_to', type='comparison_operator'),
+    # The following functions can be called without parentheses per ANSI specification
+    BareFunctionSegment=ReSegment.make(
+        r"current_timestamp|current_time|current_date", name="bare_function", type="bare_function"
+    ),
     # The strange regex here it to make sure we don't accidentally match numeric literals. We
     # also use a regex to explicitly exclude disallowed keywords.
     NakedIdentifierSegment=SegmentGenerator(
@@ -480,6 +484,7 @@ class TableExpressionSegment(BaseSegment):
             # Functions allowed here for table expressions.
             # Perhaps this should just be in a dialect, but
             # it seems sensible here for now.
+            Ref('BareFunctionSegment'),
             Ref('FunctionSegment'),
             Ref('ObjectReferenceSegment'),
             # Nested Selects
@@ -555,6 +560,7 @@ class SelectTargetElementSegment(BaseSegment):
         Sequence(
             OneOf(
                 Ref('LiteralGrammar'),
+                Ref('BareFunctionSegment'),
                 Ref('FunctionSegment'),
                 Ref('IntervalExpressionSegment'),
                 Ref('ObjectReferenceSegment'),
@@ -863,6 +869,7 @@ ansi_dialect.add(
     ),
     Expression_D_Grammar=Sequence(
         OneOf(
+            Ref('BareFunctionSegment'),
             Ref('FunctionSegment'),
             Bracketed(
                 Ref('Expression_A_Grammar')
@@ -1712,6 +1719,7 @@ class SetClauseSegment(BaseSegment):
         Ref('EqualsSegment'),
         OneOf(
             Ref('LiteralGrammar'),
+            Ref('BareFunctionSegment'),
             Ref('FunctionSegment'),
             Ref('ObjectReferenceSegment'),
             'NULL',

--- a/test/dialects_ansi_test.py
+++ b/test/dialects_ansi_test.py
@@ -54,6 +54,8 @@ def validate_segment(segmentref, config):
     [
         ("SelectKeywordSegment", "select"),
         ("NakedIdentifierSegment", "online_sales"),
+        ("BareFunctionSegment", "current_timestamp"),
+        ("FunctionSegment", "current_timestamp()"),
         ("NumericLiteralSegment", "1000.0"),
         ("ExpressionSegment", "online_sales / 1000.0"),
         ("IntervalExpressionSegment", "INTERVAL 1 YEAR"),

--- a/test/fixtures/linter/column_references_bare_function.sql
+++ b/test/fixtures/linter/column_references_bare_function.sql
@@ -1,0 +1,7 @@
+select
+    ta.column_a,
+    current_timestamp as column_b,
+    tb.column_c
+from table_a as ta
+join table_b as tb
+    using(id)

--- a/test/rules_std_test.py
+++ b/test/rules_std_test.py
@@ -240,7 +240,7 @@ def test__rules__std_string(rule, pass_fail, qry, fixed, configs):
     ('L016', 'test/fixtures/linter/block_comment_errors_2.sql', [(1, 85), (2, 86)]),
     # Column references
     ('L027', 'test/fixtures/linter/column_references.sql', [(1, 8)]),
-    ('L027', 'test/fixtures/linter/column_references_bare_function.sql', [(1, 2)]),
+    ('L027', 'test/fixtures/linter/column_references_bare_function.sql', []),
     ('L026', 'test/fixtures/linter/column_references.sql', [(1, 11)]),
     ('L025', 'test/fixtures/linter/column_references.sql', [(2, 11)]),
     # Distinct and Group by

--- a/test/rules_std_test.py
+++ b/test/rules_std_test.py
@@ -240,6 +240,7 @@ def test__rules__std_string(rule, pass_fail, qry, fixed, configs):
     ('L016', 'test/fixtures/linter/block_comment_errors_2.sql', [(1, 85), (2, 86)]),
     # Column references
     ('L027', 'test/fixtures/linter/column_references.sql', [(1, 8)]),
+    ('L027', 'test/fixtures/linter/column_references_bare_function.sql', [(1, 2)]),
     ('L026', 'test/fixtures/linter/column_references.sql', [(1, 11)]),
     ('L025', 'test/fixtures/linter/column_references.sql', [(2, 11)]),
     # Distinct and Group by


### PR DESCRIPTION
L027 would fail on ANSI functions such as `current_timestamp` or `current_date` when called without brackets. This PR adds a `BareFunctionSegment` to allow rules to treat these special cases differently.

In this case, no update to L027 is required.

Closes https://github.com/alanmcruickshank/sqlfluff/issues/418