### PR TITLE
Remove 'Unexpectedly depleted the fixes. Panic!' broken logic from main linter loop

### DIFF
--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -169,13 +169,6 @@ class LintedFile(namedtuple('ProtoFile', ['path', 'violations', 'time_dict', 'tr
             if fixed_block is None:
                 if diff_fix_codes:
                     fixed_block = diff_fix_codes.pop(0)
-                # One case is that we just consumed the last block of both, so check indexes
-                # to see if we're at the end of the raw file.
-                elif idx[0] >= len(self.file_mask[0]):
-                    # Yep we're at the end
-                    break
-                else:
-                    raise NotImplementedError("Unexpectedly depleted the fixes. Panic!")
             verbosity_logger(
                 "{0:04d}: Blocks: template:{1}, fix:{2}".format(loop_idx, templ_block, fixed_block),
                 verbosity=verbosity)

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -169,6 +169,12 @@ class LintedFile(namedtuple('ProtoFile', ['path', 'violations', 'time_dict', 'tr
             if fixed_block is None:
                 if diff_fix_codes:
                     fixed_block = diff_fix_codes.pop(0)
+                elif templ_block[0] != 'delete':
+                    # We need another fixed_block for the cases where templ_block[0] is not 'delete'
+                    raise NotImplementedError(
+                        "A {} template block remains with no more diff_fix_codes left".format(templ_block[0])
+                    )
+
             verbosity_logger(
                 "{0:04d}: Blocks: template:{1}, fix:{2}".format(loop_idx, templ_block, fixed_block),
                 verbosity=verbosity)

--- a/test/fixtures/linter/autofix/ansi/009_L010_keyword_capitalisation/.sqlfluff
+++ b/test/fixtures/linter/autofix/ansi/009_L010_keyword_capitalisation/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff:rules:L010]
+capitalisation_policy = lower

--- a/test/fixtures/linter/autofix/ansi/009_L010_keyword_capitalisation/after.sql
+++ b/test/fixtures/linter/autofix/ansi/009_L010_keyword_capitalisation/after.sql
@@ -1,0 +1,58 @@
+select
+	credits.*,
+	min(party.created_datetime) as first_party_created_datetime,
+	listagg(distinct party.product_category_code, ', ') as party_product_category_codes,
+	listagg(distinct party.product_category_name, ', ') as party_product_category_names,
+	listagg(distinct party.party_type_id, ', ') as party_type_ids,
+	listagg(distinct party.party_type, ', ') as party_types,
+	listagg(distinct party.party_action_id, ', ') as party_action_ids,
+	listagg(distinct party.party_action, ', ') as party_actions,
+	listagg(distinct party.party_incident_id, ', ') as party_incident_ids,
+	listagg(distinct party.incident, ', ') as party_incidents,
+	listagg(distinct party.product_party_package_id, ', ') as party_product_party_package_ids,
+	listagg(distinct party.product_party_party_type, ', ') as party_product_party_party_types
+from (
+	select
+		created,
+		party_transaction_id as big_transaction_id,
+		punter_id,
+		credit_amount,
+		promo_punter_reward_id,
+		NULLIF(SUBSTRING(regexp_substr(cr.description,'Ticket ref: [0-9]*'), 13), '') ::INT as ticket_id,
+		case when cr.description like 'Requesting Punter: %'
+			then left(
+				SUBSTRING(regexp_substr(cr.description,'Requesting Punter: [^/]*'), 18),
+				length(SUBSTRING(regexp_substr(cr.description,'Requesting Punter: [^/]*'), 18) )-1)
+			else null end as punter_name,
+		cr.description,
+		party_reason_id,
+		car.description as reason
+	from {{ ref("party_default__party_transaction") }} cr
+		join {{ ref("party_default__party_reason") }} car using (party_reason_id)
+	)
+group by 1,2,3,4,5,6,7,8,9
+	union
+select
+	created,
+	mgm_big_transaction_id as big_transaction_id,
+	punter_id,
+	credit_amount,
+	promo_punter_reward_id,
+	null as ticket_id,
+	null as punter_name,
+	null as description,
+	null as reason_id,
+	'raf' as reason,
+	null as first_party_created_datetime,
+	null as party_product_category_codes,
+	null as party_product_category_names,
+	null as party_type_ids,
+	null as party_types,
+	null as party_action_ids,
+	null as party_actions,
+	null as party_incident_ids,
+	null as party_incidents,
+	null as party_product_party_package_ids,
+	-- NULL as party_product_party_product_types,
+	null as party_product_party_party_types
+from {{ ref("party_default__mgm_big_transaction") }}

--- a/test/fixtures/linter/autofix/ansi/009_L010_keyword_capitalisation/before.sql
+++ b/test/fixtures/linter/autofix/ansi/009_L010_keyword_capitalisation/before.sql
@@ -1,0 +1,58 @@
+SELECT
+	credits.*,
+	min(party.created_datetime) as first_party_created_datetime,
+	listagg(distinct party.product_category_code, ', ') as party_product_category_codes,
+	listagg(distinct party.product_category_name, ', ') as party_product_category_names,
+	listagg(distinct party.party_type_id, ', ') as party_type_ids,
+	listagg(distinct party.party_type, ', ') as party_types,
+	listagg(distinct party.party_action_id, ', ') as party_action_ids,
+	listagg(distinct party.party_action, ', ') as party_actions,
+	listagg(distinct party.party_incident_id, ', ') as party_incident_ids,
+	listagg(distinct party.incident, ', ') as party_incidents,
+	listagg(distinct party.product_party_package_id, ', ') as party_product_party_package_ids,
+	listagg(distinct party.product_party_party_type, ', ') as party_product_party_party_types
+FROM (
+	SELECT
+		created,
+		party_transaction_id as big_transaction_id,
+		punter_id,
+		credit_amount,
+		promo_punter_reward_id,
+		NULLIF(SUBSTRING(regexp_substr(cr.description,'Ticket ref: [0-9]*'), 13), '') ::INT as ticket_id,
+		case when cr.description like 'Requesting Punter: %'
+			then left(
+				SUBSTRING(regexp_substr(cr.description,'Requesting Punter: [^/]*'), 18),
+				length(SUBSTRING(regexp_substr(cr.description,'Requesting Punter: [^/]*'), 18) )-1)
+			else null end as punter_name,
+		cr.description,
+		party_reason_id,
+		car.description as reason
+	from {{ ref("party_default__party_transaction") }} cr
+		join {{ ref("party_default__party_reason") }} car using (party_reason_id)
+	)
+group by 1,2,3,4,5,6,7,8,9
+	UNION
+SELECT
+	created,
+	mgm_big_transaction_id as big_transaction_id,
+	punter_id,
+	credit_amount,
+	promo_punter_reward_id,
+	null as ticket_id,
+	null as punter_name,
+	null as description,
+	null as reason_id,
+	'raf' as reason,
+	NULL as first_party_created_datetime,
+	NULL as party_product_category_codes,
+	NULL as party_product_category_names,
+	NULL as party_type_ids,
+	NULL as party_types,
+	NULL as party_action_ids,
+	NULL as party_actions,
+	NULL as party_incident_ids,
+	NULL as party_incidents,
+	NULL as party_product_party_package_ids,
+	-- NULL as party_product_party_product_types,
+	NULL as party_product_party_party_types
+from {{ ref("party_default__mgm_big_transaction") }}


### PR DESCRIPTION
The 'Unexpectedly depleted the fixes. Panic!' error was preventing the linter from fixing the file added in the test. The logic assumed that if there were no diff_fix_codes left, then we must be at the end of the raw file, and for this to be the case the length of the linted output buffer must be greater than or equal to the original file.

1. This isn't true as there could still be a delete templ_block to apply (correct in this test case)
2. The linting process could actually reduce the length of a file, meaning the lint could be completed with a smaller output buffer than the original file.