### PR TITLE
Add dialect readout command and docs

### DIFF
--- a/docs/source/dialects.rst
+++ b/docs/source/dialects.rst
@@ -15,7 +15,7 @@ current dialects available on your installation of sqlfluff.
 .. note::
 
     For technical users looking to add new dialects or add new features
-    to existing ones; the dependent nature of how dialects have been
+    to existing ones, the dependent nature of how dialects have been
     implemented is to try and reduce the amount of repetition in how
     different elements are defined. As an example, when we say that
     the :ref:`snowflake_dialect_ref` dialect *inherits* from the
@@ -47,7 +47,7 @@ isn't specifically implemented by sqlfluff, using this dialect is a good
 place to start.
 
 This dialect doesn't intend to be brutal in adhering to (and only to) the
-ANSI SQL spec *(mostly because ANSI charge for access to that spec)*. It aims
+ANSI SQL spec *(mostly because ANSI charges for access to that spec)*. It aims
 to be a representation of vanilla SQL before any other project adds their
 spin to it, and so may contain a slightly wider set of functions than actually
 available in true ANSI SQL.
@@ -99,7 +99,7 @@ The dialect for `Google BigQuery`_.
 Snowflake
 ---------
 
-The dialect for `Snowflake`_, which has much of it's syntax
+The dialect for `Snowflake`_, which has much of its syntax
 inherited from :ref:`postgres_dialect_ref`.
 
 .. _`Snowflake`: https://docs.snowflake.com/en/sql-reference.html

--- a/docs/source/dialects.rst
+++ b/docs/source/dialects.rst
@@ -1,0 +1,105 @@
+.. _dialectref:
+
+Dialects Reference
+==================
+
+Sqlfluff is designed to be flexible in supporting a variety of dialects.
+Not all potential dialects are supported so far, but several have been
+implemented by the community. Below are a list of the currently available
+dialects. Each inherits from another, up to the root `ansi` dialect.
+
+For a canonical list of supported dialects, run the
+:program:`sqlfluff dialects` command, which will output a list of the
+current dialects available on your installation of sqlfluff.
+
+.. note::
+
+    For technical users looking to add new dialects or add new features
+    to existing ones; the dependent nature of how dialects have been
+    implemented is to try and reduce the amount of repetition in how
+    different elements are defined. As an example, when we say that
+    the :ref:`snowflake_dialect_ref` dialect *inherits* from the
+    :ref:`postgres_dialect_ref` dialect this is not because there
+    is an agreement between those projects which means that features
+    in one must end up in the other, but that the design of the
+    :ref:`snowflake_dialect_ref` dialect was heavily *inspired* by the
+    postgres dialect and therefore when defining the dialect within
+    sqlfuff it makes sense to use :ref:`postgres_dialect_ref` as a
+    starting point rather than starting from scratch.
+
+    Consider when adding new features to a dialect:
+
+    - Should I be adding it just to this dialect, or adding it to
+      a *parent* dialect?
+    - If I'm creating a new dialect, which dialect would be best to
+      inherit from?
+    - Will the feature I'm adding break any *downstream* dependencies
+      within dialects which inherit from this one?
+
+.. _ansi_dialect_ref:
+
+ANSI
+----
+
+This is the base dialect which holds most of the definitions of common
+SQL commands and structures. If the dialect which you're actually using
+isn't specifically implemented by sqlfluff, using this dialect is a good
+place to start.
+
+This dialect doesn't intend to be brutal in adhering to (and only to) the
+ANSI SQL spec *(mostly because ANSI charge for access to that spec)*. It aims
+to be a representation of vanilla SQL before any other project adds their
+spin to it, and so may contain a slightly wider set of functions than actually
+available in true ANSI SQL.
+
+.. _postgres_dialect_ref:
+
+PostgreSQL
+----------
+
+This is based around the `PostgreSQL spec`_, and is also part of the
+inheritance chain for several other dialects which were heavily inspired
+by this one. The :ref:`snowflake_dialect_ref` dialect depends directly on
+this one, and if you're running `AWS Redshift`_ or `Greenplum`_ this is
+the dialect to use (until someone makes a specific dialect).
+
+.. _`PostgreSQL spec`: https://www.postgresql.org/docs/9.6/reference.html
+.. _`AWS Redshift`: https://aws.amazon.com/redshift/
+.. _`Greenplum`: https://greenplum.org/
+
+.. _mysql_dialect_ref:
+
+MySql
+-----
+
+The dialect for `MySQL`_.
+
+.. _`MySQL`: https://www.mysql.com/
+
+.. _teradata_dialect_ref:
+
+Teradata
+--------
+
+The dialect for `Teradata`_.
+
+.. _`Teradata`: https://www.teradata.co.uk/
+
+.. _bigquery_dialect_ref:
+
+BigQuery
+--------
+
+The dialect for `Google BigQuery`_.
+
+.. _`Google BigQuery`: https://cloud.google.com/bigquery/
+
+.. _snowflake_dialect_ref:
+
+Snowflake
+---------
+
+The dialect for `Snowflake`_, which has much of it's syntax
+inherited from :ref:`postgres_dialect_ref`.
+
+.. _`Snowflake`: https://docs.snowflake.com/en/sql-reference.html

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,6 +53,7 @@ Contents
    vision
    indentation
    rules
+   dialects
    production
    configuration
    architecture

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -11,12 +11,12 @@ import pstats
 from io import StringIO
 from benchit import BenchIt
 
-from ..dialects import dialect_selector
+from ..dialects import dialect_selector, dialect_readout
 from ..linter import Linter
 from .formatters import (format_config, format_rules,
                          format_violation, format_linting_result_header,
                          format_linting_result_footer, colorize,
-                         format_dialect_warning)
+                         format_dialect_warning, format_dialects)
 from .helpers import cli_table, get_package_version
 from ..config import FluffConfig
 from ..errors import SQLLintError
@@ -116,6 +116,14 @@ def rules(**kwargs):
     c = get_config(**kwargs)
     lnt = get_linter(c)
     click.echo(format_rules(lnt), color=c.get('color'))
+
+
+@cli.command()
+@common_options
+def dialects(**kwargs):
+    """Show the current dialects available."""
+    c = get_config(**kwargs)
+    click.echo(format_dialects(dialect_readout), color=c.get('color'))
 
 
 @cli.command()

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -221,3 +221,15 @@ def format_rules(linter, verbose=0):
             linter.rule_tuples(), col_width=80,
             cols=1, label_color='blue', val_align='left'))
     return text_buffer.getvalue()
+
+
+def format_dialects(dialect_readout, verbose=0):
+    """Format the dialects yielded by `dialect_readout`."""
+    text_buffer = StringIO()
+    text_buffer.write("==== sqlfluff - dialects ====\n")
+    readouts = [(d['label'], "{name} dialect [inherits from '{inherits_from}']".format(**d)) for d in dialect_readout()]
+    text_buffer.write(
+        cli_table(
+            readouts, col_width=60,
+            cols=1, label_color='blue', val_align='right'))
+    return text_buffer.getvalue()

--- a/src/sqlfluff/dialects/__init__.py
+++ b/src/sqlfluff/dialects/__init__.py
@@ -9,18 +9,30 @@ from .dialect_postgres import postgres_dialect
 from .dialect_snowflake import snowflake_dialect
 
 
+_dialect_lookup = {
+    'ansi': ansi_dialect,
+    'bigquery': bigquery_dialect,
+    'mysql': mysql_dialect,
+    'teradata': teradata_dialect,
+    'postgres': postgres_dialect,
+    'snowflake': snowflake_dialect
+}
+
+
+def dialect_readout():
+    """Generate a readout of available dialects."""
+    for dialect_label in _dialect_lookup:
+        d = _dialect_lookup[dialect_label]
+        yield {
+            'label': dialect_label, 'name': d.name,
+            'inherits_from': d.inherits_from or 'nothing'
+        }
+
+
 def dialect_selector(s):
     """Return a dialect given it's name."""
     s = s or 'ansi'
-    lookup = {
-        'ansi': ansi_dialect,
-        'bigquery': bigquery_dialect,
-        'mysql': mysql_dialect,
-        'teradata': teradata_dialect,
-        'postgres': postgres_dialect,
-        'snowflake': snowflake_dialect
-    }
-    dialect = lookup[s]
+    dialect = _dialect_lookup[s]
     # Expand any callable references at this point.
     dialect.expand()
     return dialect

--- a/src/sqlfluff/dialects/base.py
+++ b/src/sqlfluff/dialects/base.py
@@ -12,12 +12,13 @@ class Dialect:
             the lexing config for this dialect.
 
     """
-    def __init__(self, name, lexer_struct=None, library=None, sets=None):
+    def __init__(self, name, lexer_struct=None, library=None, sets=None, inherits_from=None):
         self._library = library or {}
         self.name = name
         self.lexer_struct = lexer_struct
         self.expanded = False
         self._sets = sets or {}
+        self.inherits_from = inherits_from
 
     def __repr__(self):
         return "<Dialect: {0}>".format(self.name)
@@ -76,6 +77,7 @@ class Dialect:
             library=self._library.copy(),
             lexer_struct=self.lexer_struct.copy(),
             sets=new_sets,
+            inherits_from=self.name
         )
 
     def segment(self, replace=False):

--- a/test/cli_commands_test.py
+++ b/test/cli_commands_test.py
@@ -14,7 +14,7 @@ from click.testing import CliRunner
 
 # We import the library directly here to get the version
 import sqlfluff
-from sqlfluff.cli.commands import lint, version, rules, fix, parse
+from sqlfluff.cli.commands import lint, version, rules, fix, parse, dialects
 
 
 def invoke_assert_code(ret_code=0, args=None, kwargs=None, cli_input=None):
@@ -144,8 +144,13 @@ def test__cli__command_version():
 
 
 def test__cli__command_rules():
-    """Just check rules command for exceptions."""
+    """Check rules command for exceptions."""
     invoke_assert_code(args=[rules])
+
+
+def test__cli__command_dialects():
+    """Check dialects command for exceptions."""
+    invoke_assert_code(args=[dialects])
 
 
 def generic_roundtrip_test(source_file, rulestring, final_exit_code=0, force=True, fix_input=None, fix_exit_code=0):


### PR DESCRIPTION
Fixes #435 .

I couldn't find a more elegant way of using `autodoc` to document the dialects (which would have been nice), so wrote them out longhand for the docs. The cli command is much more well integrated and tidier.