### PR TITLE
Ensure PR comment workflow only runs upstream

### DIFF
--- a/.github/workflows/ci-pr-comments.yml
+++ b/.github/workflows/ci-pr-comments.yml
@@ -17,7 +17,7 @@ jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request' && github.repository == 'sqlfluff/sqlfluff'
     steps:
       - name: 'Download txt artifact'
         uses: actions/github-script@v6


### PR DESCRIPTION
## Summary
- restrict `ci-pr-comments.yml` to only execute on sqlfluff/sqlfluff

## Testing
- `pre-commit run --files .github/workflows/ci-pr-comments.yml`

------
https://chatgpt.com/codex/tasks/task_e_6866b8067194832c92ae32a62fa868ee